### PR TITLE
Fixed wrong function name - getProvider()

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ module.exports = providers;
 ```js
 const nodeCloud = require("nodecloud");
 // AWS
-const ncProviders = nodeCloud.getProviders();
+const ncProvider = nodeCloud.getProvider();
 const options = {
   apiVersion: "2016-11-15"
 };


### PR DESCRIPTION
<h2>The node server.js kept failing giving an error about getProviders() not being a function...
Changing this name to getProvider() works...</h2>

Fixes https://github.com/cloudlibz/nodecloud/issues/6
Made nodeJS app with nodecloud module executable,
earlier, A wrong function named getProviders() was being used.
It gave an error as shown below..



## Proposed Changes

  -Changing this function's name to "getProvider()" worked...
## Before:

![troi](https://user-images.githubusercontent.com/29266591/49703118-1e797300-fc27-11e8-8b0c-1e9fc276c8c1.png)
## After:

![aa](https://user-images.githubusercontent.com/29266591/49703143-64ced200-fc27-11e8-8e76-b1ea62c49c57.png)



