### PR TITLE
Changed ec2.createInstance to ec2.create

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ const instanceParams = {
 
 const ec2 = ncProviders.aws.compute(options);
 ec2
-  .createInstance(params, instanceParams)
+  .create(params, instanceParams)
   .then(res => {
     console.log(`All done ! ${res}`);
   })


### PR DESCRIPTION
Fixes #

The EC2 function of the NodeCloud AWS plugin does not contain a function 'ec2.createInstance', instead it is 'create'

## Proposed Changes

Changed ec2.createInstance to ec2.create