### PR TITLE
Improve error handling in core/base-provider.js

### DIFF
--- a/lib/core/base-provider.js
+++ b/lib/core/base-provider.js
@@ -26,10 +26,20 @@ class Provider {
 
     let providersToLoad = {};
 
-    if (options !== undefined && options.hasOwnProperty("overrideProviders")) {
+    if (
+      options !== null &&
+      options !== undefined &&
+      options.hasOwnProperty("overrideProviders")
+    ) {
       ncConfig.map(provider => {
         const module = provider.plugin;
-        providersToLoad[provider.tag] = module(provider.configPath);
+        try {
+          providersToLoad[provider.tag] = module(provider.configPath);
+        } catch (err) {
+          throw new Error(
+            "🤖  It seems you have not added a valid cloud provider"
+          );
+        }
       });
     } else {
       ncConfig.map(provider => {
@@ -38,7 +48,13 @@ class Provider {
         }
 
         const module = provider.plugin;
-        providersToLoad[provider.tag] = module(provider.configPath);
+        try {
+          providersToLoad[provider.tag] = module(provider.configPath);
+        } catch (err) {
+          throw new Error(
+            "🤖  It seems you have not added a valid cloud provider"
+          );
+        }
       });
     }
 

--- a/lib/core/base-provider.js
+++ b/lib/core/base-provider.js
@@ -26,10 +26,20 @@ class Provider {
 
     let providersToLoad = {};
 
-    if (options !== undefined && options.hasOwnProperty("overrideProviders")) {
+    if (
+      options !== null &&
+      options !== undefined &&
+      options.hasOwnProperty("overrideProviders")
+    ) {
       ncConfig.map(provider => {
         const module = provider.plugin;
-        providersToLoad[provider.tag] = module(provider.configPath);
+        try {
+          providersToLoad[provider.tag] = module(provider.configPath);
+        } catch (err) {
+          throw new Error(
+            "It seems you have not added any valid cloud provider"
+          );
+        }
       });
     } else {
       ncConfig.map(provider => {
@@ -38,7 +48,13 @@ class Provider {
         }
 
         const module = provider.plugin;
-        providersToLoad[provider.tag] = module(provider.configPath);
+        try {
+          providersToLoad[provider.tag] = module(provider.configPath);
+        } catch (err) {
+          throw new Error(
+            "It seems you have not added any valid cloud provider"
+          );
+        }
       });
     }
 


### PR DESCRIPTION
## Proposed Changes

  - Added ```try...catch``` block to handle errors when ```nodecloud-<cloud-provider>-plugin``` is not provided or a valid, supported cloud provider is not added.
  - Added an extra check condition in ```getProviders(options)``` to check if options is not ```null```, which otherwise would throw error when ``` options.hasOwnProperty("overrideProviders")``` tries to read properties of null object.
 