### PR TITLE
Fix nodecloud ec2 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ const options = {
 const params = {
   ImageId: "ami-10fd7020", // amzn-ami-2011.09.1.x86_64-ebs
   InstanceType: "t1.micro",
+  KeyName: "nodeCloud", // key name of Key pair
   MinCount: 1,
   MaxCount: 1
 };

--- a/examples/compute/aws-ec2.js
+++ b/examples/compute/aws-ec2.js
@@ -1,23 +1,60 @@
 const nodeCloud = require("../../lib/");
-const ncAWS = nodeCloud.getProvider("AWS", process.env.ncconf);
+const optionsProvider = {
+  overrideProviders: false
+};
+const ncProviders = nodeCloud.getProviders(optionsProvider);
 const options = {
   apiVersion: "2016-11-15"
 };
 
 // get compute object for AWS
-const ec2 = ncAWS.compute(options);
+const ec2 = ncProviders.aws.compute(options);
 
-// create AWS EC2 instance
-const params = {
-  InstanceIds: ["i-0de2ae0ba47d4f3f3"],
-  DryRun: true
-};
+function launchInstance() {
+  const params = {
+    Key: "Name",
+    Value: "Node Cloud Demo"
+  };
+  const instanceParams = {
+    ImageId: "ami-07ebfd5b3428b6f4d", // Image of Ubuntu Server 18.04 LTS
+    InstanceType: "t2.micro",
+    KeyName: "nodeCloud", // key name of Key pair
+    MinCount: 1,
+    MaxCount: 1
+  };
 
-ec2
-  .stop(params)
-  .then(res => {
-    console.log(res);
-  })
-  .catch(err => {
-    console.log(err);
-  });
+  // create AWS EC2 instance
+  ec2
+    .create(instanceParams, params)
+    .then(res => {
+      console.log(`All done ! ${res}`);
+    })
+    .catch(err => {
+      console.log(`Oops something happened ${err}`);
+    });
+}
+
+function stopInstance() {
+  const params = {
+    InstanceIds: ["i-04d2495f3acccea8e"],
+    DryRun: false
+  };
+
+  // stop AWS EC2 instance
+  ec2
+    .stop(params)
+    .then(res => {
+      console.log(res);
+    })
+    .catch(err => {
+      console.log(err);
+    });
+}
+
+const functionToDemo = "create"; // set which function to demo
+
+if (functionToDemo === "create") {
+  launchInstance();
+} else if (functionToDemo === "stop") {
+  stopInstance();
+}


### PR DESCRIPTION
Fixes #36 

## Proposed Changes

  - The AWS ec2 example has been updated with the correct `getProviders` function 
  - Create instance function is added in example  
  - The missing parameter of the example in the `readme` file was added 

## Related Fixes in node cloud AWS plugin 
 *  Enhancement fixes were done in node cloud aws plugin while testing the example https://github.com/cloudlibz/nodecloud-aws-plugin/pull/12 