### PR TITLE
path join --> resolve

### DIFF
--- a/lib/core/base-provider.js
+++ b/lib/core/base-provider.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const ncConfig = require(path.join(process.cwd(), ".nc.config"));
+const ncConfig = require(path.resolve(process.cwd(), ".nc.config"));
 const validProviders = require("./providers-list");
 
 class Provider {


### PR DESCRIPTION
Fixes #31

## Proposed Changes

  - Changed path.join to path.resolve
  - Resolve will treat this as the root directory, and ignore all previous paths and another thing to note is that path.resolve will always result in an absolute URL, and will use your working directory as a base to resolve this path. 
  
