### PR TITLE
Mocha unit tests for generators

### DIFF
--- a/generator/generators/aws/generator.ts
+++ b/generator/generators/aws/generator.ts
@@ -26,56 +26,60 @@ const dummyAst = createSourceFile(
   ScriptTarget.Latest,
   true
 );
-let sdkClassAst;
-let sdkFile;
 
-export function generateAWSClass(serviceClass) {
-  const functions = [];
+export function extractSDKData(sdkClassAst, serviceClass) {
   let methods: FunctionData[] = [];
+  const functions = [];
 
   Object.keys(serviceClass).map((key, index) => {
     functions.push(serviceClass[key].split(" ")[1]);
-    sdkFile = serviceClass[key].split(" ")[0];
   });
 
-  getAST(sdkFile).then(result => {
-    sdkClassAst = result;
-    try {
-      sdkClassAst.members.map(method => {
-        if (method.name && functions.includes(method.name.text)) {
-          let name;
-          Object.keys(serviceClass).map((key, index) => {
-            if (serviceClass[key].split(" ")[1] === method.name.text) {
-              name = key;
-            }
-          });
+  sdkClassAst.members.map(method => {
+    if (method.name && functions.includes(method.name.text)) {
+      let name;
+      Object.keys(serviceClass).map((key, index) => {
+        if (serviceClass[key].split(" ")[1] === method.name.text) {
+          name = key;
+        }
+      });
 
-          const parameters = [];
-          method.parameters.map(param => {
-            if (param.name.text !== "callback") {
-              parameters.push({
-                name: param.name.text,
-                optional: param.questionToken ? true : false,
-                type: SyntaxKind[param.type.kind]
-              });
-            }
-          });
-
-          methods.push({
-            functionName: name.toString(),
-            SDKFunctionName: method.name.text.toString(),
-            params: parameters
+      const parameters = [];
+      method.parameters.map(param => {
+        if (param.name.text !== "callback") {
+          parameters.push({
+            name: param.name.text,
+            optional: param.questionToken ? true : false,
+            type: SyntaxKind[param.type.kind]
           });
         }
       });
 
-      const groupedMethods = groupers.aws(methods);
-      methods = filters.aws(groupedMethods);
+      methods.push({
+        functionName: name.toString(),
+        SDKFunctionName: method.name.text.toString(),
+        params: parameters
+      });
+    }
+  });
 
-      const classData: ClassData = {
-        className: sdkClassAst.name.text,
-        functions: methods
-      };
+  const groupedMethods = groupers.aws(methods);
+  methods = filters.aws(groupedMethods);
+
+  const classData: ClassData = {
+    className: sdkClassAst.name.text,
+    functions: methods
+  };
+
+  return classData;
+}
+
+export function generateAWSClass(serviceClass) {
+  const sdkFile = serviceClass[Object.keys(serviceClass)[0]].split(" ")[0];
+  getAST(sdkFile).then(result => {
+    const sdkClassAst = result;
+    try {
+      const classData = extractSDKData(sdkClassAst, serviceClass);
       const output = transform(dummyAst, classData);
       printFile(
         process.cwd() + "/generatedClasses/AWS/" + classData.className + ".js",

--- a/generator/generators/azure/generator.js
+++ b/generator/generators/azure/generator.js
@@ -133,7 +133,7 @@ var __generator =
     }
   };
 exports.__esModule = true;
-exports.generateAzureClass = void 0;
+exports.generateAzureClass = exports.extractSDKData = void 0;
 var fs = require("fs");
 var typescript_1 = require("typescript");
 var parser_1 = require("../../parsers/azure/parser");
@@ -146,9 +146,56 @@ var dummyAst = typescript_1.createSourceFile(
   typescript_1.ScriptTarget.Latest,
   true
 );
+function extractSDKData(sdkFiles, methods) {
+  sdkFiles.map(function(sdkFile) {
+    sdkFile.ast.members.map(function(member) {
+      if (typescript_1.SyntaxKind[member.kind] === "Constructor") {
+        member.parameters.map(function(param) {
+          var tempStr = param.type.typeName.text.split(/(?=[A-Z])/);
+          tempStr.pop();
+          sdkFile.client = tempStr.join("");
+        });
+      }
+      if (
+        typescript_1.SyntaxKind[member.kind] === "MethodDeclaration" &&
+        sdkFile.sdkFunctionNames.includes(member.name.text)
+      ) {
+        var method = methods.find(function(methd) {
+          return methd.SDKFunctionName === member.name.text;
+        });
+        var parameters = member.parameters.map(function(param) {
+          return {
+            name: param.name.text,
+            optional: param.questionToken ? true : false,
+            type: typescript_1.SyntaxKind[param.type.kind]
+          };
+        });
+        var returnType = typescript_1.SyntaxKind[member.type.kind];
+        if (!method.returnType) {
+          method.params = parameters;
+          method.returnType = returnType;
+          method.client = sdkFile.client;
+        } else {
+          var clone = JSON.parse(JSON.stringify(method));
+          clone.params = parameters;
+          clone.returnType = returnType;
+          clone.client = sdkFile.client;
+          methods.push(clone);
+        }
+      }
+    });
+  });
+  var groupedMethods = helper_1.groupers.azure(methods);
+  methods = helper_1.filters.azure(groupedMethods);
+  var classData = {
+    functions: methods
+  };
+  return classData;
+}
+exports.extractSDKData = extractSDKData;
 function generateAzureClass(serviceClass) {
   return __awaiter(this, void 0, void 0, function() {
-    var methods, files, sdkFiles, groupedMethods, classData, output;
+    var methods, files, sdkFiles, classData, output;
     var _this = this;
     return __generator(this, function(_a) {
       switch (_a.label) {
@@ -209,49 +256,7 @@ function generateAzureClass(serviceClass) {
           ];
         case 1:
           _a.sent();
-          sdkFiles.map(function(sdkFile) {
-            sdkFile.ast.members.map(function(member) {
-              if (typescript_1.SyntaxKind[member.kind] === "Constructor") {
-                member.parameters.map(function(param) {
-                  var tempStr = param.type.typeName.text.split(/(?=[A-Z])/);
-                  tempStr.pop();
-                  sdkFile.client = tempStr.join("");
-                });
-              }
-              if (
-                typescript_1.SyntaxKind[member.kind] === "MethodDeclaration" &&
-                sdkFile.sdkFunctionNames.includes(member.name.text)
-              ) {
-                var method = methods.find(function(methd) {
-                  return methd.SDKFunctionName === member.name.text;
-                });
-                var parameters = member.parameters.map(function(param) {
-                  return {
-                    name: param.name.text,
-                    optional: param.questionToken ? true : false,
-                    type: typescript_1.SyntaxKind[param.type.kind]
-                  };
-                });
-                var returnType = typescript_1.SyntaxKind[member.type.kind];
-                if (!method.returnType) {
-                  method.params = parameters;
-                  method.returnType = returnType;
-                  method.client = sdkFile.client;
-                } else {
-                  var clone = JSON.parse(JSON.stringify(method));
-                  clone.params = parameters;
-                  clone.returnType = returnType;
-                  clone.client = sdkFile.client;
-                  methods.push(clone);
-                }
-              }
-            });
-          });
-          groupedMethods = helper_1.groupers.azure(methods);
-          methods = helper_1.filters.azure(groupedMethods);
-          classData = {
-            functions: methods
-          };
+          classData = extractSDKData(sdkFiles, methods);
           output = transformer_1.transform(dummyAst, classData);
           helper_1.printFile(
             process.cwd() +

--- a/generator/generators/azure/generator.js
+++ b/generator/generators/azure/generator.js
@@ -147,6 +147,7 @@ var dummyAst = typescript_1.createSourceFile(
   true
 );
 function extractSDKData(sdkFiles, methods) {
+  var specifiedMethods = JSON.parse(JSON.stringify(methods));
   sdkFiles.map(function(sdkFile) {
     sdkFile.ast.members.map(function(member) {
       if (typescript_1.SyntaxKind[member.kind] === "Constructor") {
@@ -185,6 +186,9 @@ function extractSDKData(sdkFiles, methods) {
       }
     });
   });
+  if (JSON.stringify(methods) === JSON.stringify(specifiedMethods)) {
+    throw new Error("Data extraction unsuccessful");
+  }
   var groupedMethods = helper_1.groupers.azure(methods);
   methods = helper_1.filters.azure(groupedMethods);
   var classData = {

--- a/generator/generators/azure/generator.ts
+++ b/generator/generators/azure/generator.ts
@@ -28,6 +28,7 @@ const dummyAst = createSourceFile(
 );
 
 export function extractSDKData(sdkFiles, methods) {
+  const specifiedMethods = JSON.parse(JSON.stringify(methods));
   sdkFiles.map(sdkFile => {
     sdkFile.ast.members.map(member => {
       if (SyntaxKind[member.kind] === "Constructor") {
@@ -69,6 +70,10 @@ export function extractSDKData(sdkFiles, methods) {
       }
     });
   });
+
+  if (JSON.stringify(methods) === JSON.stringify(specifiedMethods)) {
+    throw new Error("Data extraction unsuccessful");
+  }
 
   const groupedMethods = groupers.azure(methods);
   methods = filters.azure(groupedMethods);

--- a/generator/generators/googleCloud/generator.js
+++ b/generator/generators/googleCloud/generator.js
@@ -150,6 +150,7 @@ var dummyAst = typescript_1.createSourceFile(
 );
 function extractClassBasedSDKData(methods, sdkFiles) {
   var _this = this;
+  var specifiedMethods = JSON.parse(JSON.stringify(methods));
   return new Promise(function(resolve, reject) {
     return __awaiter(_this, void 0, void 0, function() {
       var classes_1, extractedData;
@@ -254,7 +255,11 @@ function extractClassBasedSDKData(methods, sdkFiles) {
             classes: classes_1,
             methods: methods
           };
-          resolve(extractedData);
+          if (JSON.stringify(methods) === JSON.stringify(specifiedMethods)) {
+            reject(new Error("Data extraction unsuccessful"));
+          } else {
+            resolve(extractedData);
+          }
         } catch (error) {
           reject(error);
         }
@@ -266,6 +271,7 @@ function extractClassBasedSDKData(methods, sdkFiles) {
 exports.extractClassBasedSDKData = extractClassBasedSDKData;
 function extractClientBasedSDKdata(methods, sdkFiles) {
   var _this = this;
+  var specifiedMethods = JSON.parse(JSON.stringify(methods));
   return new Promise(function(resolve, reject) {
     return __awaiter(_this, void 0, void 0, function() {
       return __generator(this, function(_a) {
@@ -305,7 +311,11 @@ function extractClientBasedSDKdata(methods, sdkFiles) {
               }
             });
           });
-          resolve(methods);
+          if (JSON.stringify(methods) === JSON.stringify(specifiedMethods)) {
+            reject(new Error("Data extraction unsuccessful"));
+          } else {
+            resolve(methods);
+          }
         } catch (error) {
           reject(error);
         }

--- a/generator/generators/googleCloud/generator.js
+++ b/generator/generators/googleCloud/generator.js
@@ -133,7 +133,7 @@ var __generator =
     }
   };
 exports.__esModule = true;
-exports.generateGCPClass = void 0;
+exports.generateGCPClass = exports.extractClientBasedSDKdata = exports.extractClassBasedSDKData = void 0;
 var fs = require("fs");
 var path = require("path");
 var typescript_1 = require("typescript");
@@ -148,72 +148,27 @@ var dummyAst = typescript_1.createSourceFile(
   typescript_1.ScriptTarget.Latest,
   true
 );
-function extractClientBasedSDKdata(methods) {
+function extractClassBasedSDKData(methods, sdkFiles) {
   var _this = this;
   return new Promise(function(resolve, reject) {
     return __awaiter(_this, void 0, void 0, function() {
-      var files, sdkFiles, error_1;
-      var _this = this;
+      var classes_1, extractedData;
       return __generator(this, function(_a) {
-        switch (_a.label) {
-          case 0:
-            _a.trys.push([0, 2, , 3]);
-            files = Array.from(
-              new Set(
-                methods.map(function(method) {
-                  return method.fileName + " " + method.version;
-                })
-              )
-            );
-            sdkFiles = files.map(function(file) {
-              return {
-                fileName: file.split(" ")[0],
-                version: file.split(" ")[1],
-                pkgName: methods[0].pkgName,
-                ast: null,
-                client: null,
-                sdkFunctionNames: methods
-                  .filter(function(method) {
-                    return method.fileName === file.split(" ")[0];
-                  })
-                  .map(function(method) {
-                    return method.SDKFunctionName;
-                  })
+        try {
+          classes_1 = [];
+          sdkFiles.map(function(file) {
+            file.classes.map(function(classAst) {
+              var classInfo = {
+                name: classAst.name.text,
+                methods: [],
+                properties: [],
+                constructor: null
               };
-            });
-            return [
-              4 /*yield*/,
-              Promise.all(
-                sdkFiles.map(function(file) {
-                  return __awaiter(_this, void 0, void 0, function() {
-                    var _a;
-                    return __generator(this, function(_b) {
-                      switch (_b.label) {
-                        case 0:
-                          _a = file;
-                          return [4 /*yield*/, parser_1.getAST(file)];
-                        case 1:
-                          _a.ast = _b.sent();
-                          return [2 /*return*/];
-                      }
-                    });
-                  });
-                })
-              )
-            ];
-          case 1:
-            _a.sent();
-            sdkFiles.map(function(sdkFile) {
-              sdkFile.client = sdkFile.ast.name.text;
-              sdkFile.ast.members.map(function(member) {
+              classAst.members.map(function(member) {
                 if (
-                  typescript_1.SyntaxKind[member.kind] ===
-                    "MethodDeclaration" &&
-                  sdkFile.sdkFunctionNames.includes(member.name.text)
+                  typescript_1.SyntaxKind[member.kind] === "MethodDeclaration"
                 ) {
-                  var method = methods.find(function(methd) {
-                    return methd.SDKFunctionName === member.name.text;
-                  });
+                  var returnType = typescript_1.SyntaxKind[member.type.kind];
                   var parameters = member.parameters.map(function(param) {
                     return {
                       name: param.name.text,
@@ -221,74 +176,179 @@ function extractClientBasedSDKdata(methods) {
                       type: typescript_1.SyntaxKind[param.type.kind]
                     };
                   });
-                  var returnType = typescript_1.SyntaxKind[member.type.kind];
+                  var method_1 = {
+                    pkgName: file.pkgName,
+                    version: null,
+                    fileName: file.fileName,
+                    functionName: null,
+                    SDKFunctionName: member.name.text,
+                    params: parameters,
+                    returnType: returnType,
+                    returnTypeName: null,
+                    client: classAst.name.text // Class name
+                  };
                   if (returnType === "TypeReference") {
-                    method.returnTypeName = member.type.typeName.text;
+                    method_1.returnTypeName = member.type.typeName.text;
                   }
-                  if (!method.returnType) {
-                    method.params = parameters;
-                    method.returnType = returnType;
-                    method.client = sdkFile.client;
-                  } else {
-                    var clone = JSON.parse(JSON.stringify(method));
-                    clone.params = parameters;
-                    clone.returnType = returnType;
-                    clone.client = sdkFile.client;
-                    methods.push(clone);
+                  var meth = methods.find(function(meth) {
+                    return (
+                      meth.SDKFunctionName === method_1.SDKFunctionName &&
+                      meth.fileName === method_1.fileName
+                    );
+                  });
+                  method_1.functionName = meth ? meth.functionName : null;
+                  classInfo.methods.push(method_1);
+                }
+                if (typescript_1.SyntaxKind[member.kind] === "Constructor") {
+                  var parameters = member.parameters.map(function(param) {
+                    return {
+                      name: param.name.text,
+                      optional: param.questionToken ? true : false,
+                      type: typescript_1.SyntaxKind[param.type.kind],
+                      typeRefName: param.type.typeName
+                        ? param.type.typeName.text
+                        : null
+                    };
+                  });
+                  classInfo.constructor = {
+                    parameters: parameters
+                  };
+                }
+                if (
+                  typescript_1.SyntaxKind[member.kind] === "PropertyDeclaration"
+                ) {
+                  var isPrivateProp =
+                    member.modifiers &&
+                    member.modifiers.some(function(modifier) {
+                      return (
+                        typescript_1.SyntaxKind[modifier.kind] ===
+                        "PrivateKeyword"
+                      );
+                    });
+                  if (!isPrivateProp) {
+                    var prop = {
+                      name: member.name.text,
+                      type: typescript_1.SyntaxKind[member.type.kind],
+                      typeRefName: member.type.typeName
+                        ? member.type.typeName.text
+                        : null
+                    };
+                    classInfo.properties.push(prop);
                   }
                 }
               });
+              classes_1.push(classInfo);
             });
-            resolve(methods);
-            return [3 /*break*/, 3];
-          case 2:
-            error_1 = _a.sent();
-            reject(error_1);
-            return [3 /*break*/, 3];
-          case 3:
-            return [2 /*return*/];
+          });
+          methods = [];
+          classes_1.map(function(classData) {
+            var filteredMethods = classData.methods.filter(function(meth) {
+              return meth.functionName !== null;
+            });
+            filteredMethods.map(function(filMeth) {
+              filMeth.classConstructorData = classData.constructor;
+            });
+            methods = methods.concat(filteredMethods);
+          });
+          extractedData = {
+            classes: classes_1,
+            methods: methods
+          };
+          resolve(extractedData);
+        } catch (error) {
+          reject(error);
         }
+        return [2 /*return*/];
       });
     });
   });
 }
-function extractClassBasedSDKData(methods) {
+exports.extractClassBasedSDKData = extractClassBasedSDKData;
+function extractClientBasedSDKdata(methods, sdkFiles) {
   var _this = this;
   return new Promise(function(resolve, reject) {
     return __awaiter(_this, void 0, void 0, function() {
-      var dirPath, files, sdkFiles, classes_1, extractedData, error_2;
-      var _this = this;
       return __generator(this, function(_a) {
-        switch (_a.label) {
-          case 0:
-            _a.trys.push([0, 2, , 3]);
-            dirPath =
-              "../../../node_modules/@google-cloud/" +
-              methods[0].pkgName +
-              "/build/src/";
-            files = fs.readdirSync(path.join(__dirname, dirPath));
-            files = files.filter(function(fileName) {
-              return (
-                fileName.split(".")[1] === "d" &&
-                fileName.split(".")[2] === "ts"
-              );
+        try {
+          sdkFiles.map(function(sdkFile) {
+            sdkFile.client = sdkFile.ast.name.text;
+            sdkFile.ast.members.map(function(member) {
+              if (
+                typescript_1.SyntaxKind[member.kind] === "MethodDeclaration" &&
+                sdkFile.sdkFunctionNames.includes(member.name.text)
+              ) {
+                var method = methods.find(function(methd) {
+                  return methd.SDKFunctionName === member.name.text;
+                });
+                var parameters = member.parameters.map(function(param) {
+                  return {
+                    name: param.name.text,
+                    optional: param.questionToken ? true : false,
+                    type: typescript_1.SyntaxKind[param.type.kind]
+                  };
+                });
+                var returnType = typescript_1.SyntaxKind[member.type.kind];
+                if (returnType === "TypeReference") {
+                  method.returnTypeName = member.type.typeName.text;
+                }
+                if (!method.returnType) {
+                  method.params = parameters;
+                  method.returnType = returnType;
+                  method.client = sdkFile.client;
+                } else {
+                  var clone = JSON.parse(JSON.stringify(method));
+                  clone.params = parameters;
+                  clone.returnType = returnType;
+                  clone.client = sdkFile.client;
+                  methods.push(clone);
+                }
+              }
             });
-            sdkFiles = files.map(function(fileName) {
-              return {
-                fileName: fileName,
-                pkgName: methods[0].pkgName,
-                classes: null,
-                sdkFunctionNames: methods
-                  .filter(function(method) {
-                    return method.fileName === fileName;
-                  })
-                  .map(function(method) {
-                    return method.SDKFunctionName;
-                  })
-              };
-            });
-            return [
-              4 /*yield*/,
+          });
+          resolve(methods);
+        } catch (error) {
+          reject(error);
+        }
+        return [2 /*return*/];
+      });
+    });
+  });
+}
+exports.extractClientBasedSDKdata = extractClientBasedSDKdata;
+function generateClassBasedCode(methods, data) {
+  return __awaiter(this, void 0, void 0, function() {
+    var dirPath, files, sdkFiles, extractedData, groupedMethods, output;
+    var _this = this;
+    return __generator(this, function(_a) {
+      switch (_a.label) {
+        case 0:
+          dirPath =
+            "../../../node_modules/@google-cloud/" +
+            methods[0].pkgName +
+            "/build/src/";
+          files = fs.readdirSync(path.join(__dirname, dirPath));
+          files = files.filter(function(fileName) {
+            return (
+              fileName.split(".")[1] === "d" && fileName.split(".")[2] === "ts"
+            );
+          });
+          sdkFiles = files.map(function(fileName) {
+            return {
+              fileName: fileName,
+              pkgName: methods[0].pkgName,
+              classes: null,
+              sdkFunctionNames: methods
+                .filter(function(method) {
+                  return method.fileName === fileName;
+                })
+                .map(function(method) {
+                  return method.SDKFunctionName;
+                })
+            };
+          });
+          return [
+            4 /*yield*/,
+            Promise.all(
               sdkFiles.map(function(file) {
                 return __awaiter(_this, void 0, void 0, function() {
                   var _a;
@@ -304,206 +364,17 @@ function extractClassBasedSDKData(methods) {
                   });
                 });
               })
-            ];
-          case 1:
-            _a.sent();
-            classes_1 = [];
-            sdkFiles.map(function(file) {
-              file.classes.map(function(classAst) {
-                var classInfo = {
-                  name: classAst.name.text,
-                  methods: [],
-                  properties: [],
-                  constructor: null
-                };
-                classAst.members.map(function(member) {
-                  if (
-                    typescript_1.SyntaxKind[member.kind] === "MethodDeclaration"
-                  ) {
-                    var returnType = typescript_1.SyntaxKind[member.type.kind];
-                    var parameters = member.parameters.map(function(param) {
-                      return {
-                        name: param.name.text,
-                        optional: param.questionToken ? true : false,
-                        type: typescript_1.SyntaxKind[param.type.kind]
-                      };
-                    });
-                    var method_1 = {
-                      pkgName: file.pkgName,
-                      version: null,
-                      fileName: file.fileName,
-                      functionName: null,
-                      SDKFunctionName: member.name.text,
-                      params: parameters,
-                      returnType: returnType,
-                      returnTypeName: null,
-                      client: classAst.name.text // Class name
-                    };
-                    if (returnType === "TypeReference") {
-                      method_1.returnTypeName = member.type.typeName.text;
-                    }
-                    var meth = methods.find(function(meth) {
-                      return (
-                        meth.SDKFunctionName === method_1.SDKFunctionName &&
-                        meth.fileName === method_1.fileName
-                      );
-                    });
-                    method_1.functionName = meth ? meth.functionName : null;
-                    classInfo.methods.push(method_1);
-                  }
-                  if (typescript_1.SyntaxKind[member.kind] === "Constructor") {
-                    var parameters = member.parameters.map(function(param) {
-                      return {
-                        name: param.name.text,
-                        optional: param.questionToken ? true : false,
-                        type: typescript_1.SyntaxKind[param.type.kind],
-                        typeRefName: param.type.typeName
-                          ? param.type.typeName.text
-                          : null
-                      };
-                    });
-                    classInfo.constructor = {
-                      parameters: parameters
-                    };
-                  }
-                  if (
-                    typescript_1.SyntaxKind[member.kind] ===
-                    "PropertyDeclaration"
-                  ) {
-                    var isPrivateProp =
-                      member.modifiers &&
-                      member.modifiers.some(function(modifier) {
-                        return (
-                          typescript_1.SyntaxKind[modifier.kind] ===
-                          "PrivateKeyword"
-                        );
-                      });
-                    if (!isPrivateProp) {
-                      var prop = {
-                        name: member.name.text,
-                        type: typescript_1.SyntaxKind[member.type.kind],
-                        typeRefName: member.type.typeName
-                          ? member.type.typeName.text
-                          : null
-                      };
-                      classInfo.properties.push(prop);
-                    }
-                  }
-                });
-                classes_1.push(classInfo);
-              });
-            });
-            methods = [];
-            classes_1.map(function(classData) {
-              var filteredMethods = classData.methods.filter(function(meth) {
-                return meth.functionName !== null;
-              });
-              filteredMethods.map(function(filMeth) {
-                filMeth.classConstructorData = classData.constructor;
-              });
-              methods = methods.concat(filteredMethods);
-            });
-            extractedData = {
-              classes: classes_1,
-              methods: methods
-            };
-            resolve(extractedData);
-            return [3 /*break*/, 3];
-          case 2:
-            error_2 = _a.sent();
-            reject(error_2);
-            return [3 /*break*/, 3];
-          case 3:
-            return [2 /*return*/];
-        }
-      });
-    });
-  });
-}
-function generateGCPClass(serviceClass) {
-  return __awaiter(this, void 0, void 0, function() {
-    var methods,
-      data,
-      groupedMethods,
-      classData,
-      output,
-      extractedData,
-      groupedMethods,
-      output;
-    return __generator(this, function(_a) {
-      switch (_a.label) {
-        case 0:
-          methods = [];
-          data = {};
-          Object.keys(serviceClass).map(function(key, index) {
-            if (key === "mainClass") {
-              data.mainClass = serviceClass[key];
-            } else if (
-              serviceClass[key].split(" ")[1].length === 2 &&
-              serviceClass[key].split(" ")[1].charAt(0) === "v"
-            ) {
-              methods.push({
-                pkgName: serviceClass[key].split(" ")[0],
-                version: serviceClass[key].split(" ")[1],
-                fileName: serviceClass[key].split(" ")[2],
-                functionName: key,
-                SDKFunctionName: serviceClass[key].split(" ")[3],
-                params: [],
-                returnType: null,
-                returnTypeName: null,
-                client: null
-              });
-            } else {
-              methods.push({
-                pkgName: serviceClass[key].split(" ")[0],
-                version: null,
-                fileName: serviceClass[key].split(" ")[1],
-                functionName: key,
-                SDKFunctionName: serviceClass[key].split(" ")[2],
-                params: [],
-                returnType: null,
-                returnTypeName: null,
-                client: null
-              });
-            }
-          });
-          if (!methods[0].version) return [3 /*break*/, 2];
-          return [
-            4 /*yield*/,
-            extractClientBasedSDKdata(methods).then(function(result) {
-              return result;
-            })
+            )
           ];
         case 1:
-          methods = _a.sent();
-          groupedMethods = helper_1.groupers.gcp(methods);
-          methods = helper_1.filters.gcp(groupedMethods);
-          classData = {
-            functions: methods
-          };
-          output = clientBasedTransformer_1.clientBasedTransform(
-            dummyAst,
-            classData
-          );
-          fs.writeFile(
-            process.cwd() +
-              "/generatedClasses/googleCloud/" +
-              classData.functions[0].pkgName +
-              ".js",
-            output,
-            function(err) {
-              if (err) throw err;
-            }
-          );
-          return [3 /*break*/, 4];
-        case 2:
+          _a.sent();
           return [
             4 /*yield*/,
-            extractClassBasedSDKData(methods).then(function(result) {
+            extractClassBasedSDKData(methods, sdkFiles).then(function(result) {
               return result;
             })
           ];
-        case 3:
+        case 2:
           extractedData = _a.sent();
           groupedMethods = helper_1.groupers.gcp(extractedData.methods);
           methods = helper_1.filters.gcp(groupedMethods);
@@ -517,10 +388,136 @@ function generateGCPClass(serviceClass) {
               ".js",
             output
           );
-          _a.label = 4;
-        case 4:
           return [2 /*return*/];
       }
+    });
+  });
+}
+function generateClientBasedCode(methods) {
+  return __awaiter(this, void 0, void 0, function() {
+    var files, sdkFiles, groupedMethods, classData, output;
+    var _this = this;
+    return __generator(this, function(_a) {
+      switch (_a.label) {
+        case 0:
+          files = Array.from(
+            new Set(
+              methods.map(function(method) {
+                return method.fileName + " " + method.version;
+              })
+            )
+          );
+          sdkFiles = files.map(function(file) {
+            return {
+              fileName: file.split(" ")[0],
+              version: file.split(" ")[1],
+              pkgName: methods[0].pkgName,
+              ast: null,
+              client: null,
+              sdkFunctionNames: methods
+                .filter(function(method) {
+                  return method.fileName === file.split(" ")[0];
+                })
+                .map(function(method) {
+                  return method.SDKFunctionName;
+                })
+            };
+          });
+          return [
+            4 /*yield*/,
+            Promise.all(
+              sdkFiles.map(function(file) {
+                return __awaiter(_this, void 0, void 0, function() {
+                  var _a;
+                  return __generator(this, function(_b) {
+                    switch (_b.label) {
+                      case 0:
+                        _a = file;
+                        return [4 /*yield*/, parser_1.getAST(file)];
+                      case 1:
+                        _a.ast = _b.sent();
+                        return [2 /*return*/];
+                    }
+                  });
+                });
+              })
+            )
+          ];
+        case 1:
+          _a.sent();
+          return [
+            4 /*yield*/,
+            extractClientBasedSDKdata(methods, sdkFiles).then(function(result) {
+              return result;
+            })
+          ];
+        case 2:
+          methods = _a.sent();
+          groupedMethods = helper_1.groupers.gcp(methods);
+          methods = helper_1.filters.gcp(groupedMethods);
+          classData = {
+            functions: methods
+          };
+          output = clientBasedTransformer_1.clientBasedTransform(
+            dummyAst,
+            classData
+          );
+          helper_1.printFile(
+            process.cwd() +
+              "/generatedClasses/googleCloud/" +
+              classData.functions[0].pkgName +
+              ".js",
+            output
+          );
+          return [2 /*return*/];
+      }
+    });
+  });
+}
+function generateGCPClass(serviceClass) {
+  return __awaiter(this, void 0, void 0, function() {
+    var methods, data;
+    return __generator(this, function(_a) {
+      methods = [];
+      data = {};
+      Object.keys(serviceClass).map(function(key, index) {
+        if (key === "mainClass") {
+          data.mainClass = serviceClass[key];
+        } else if (
+          serviceClass[key].split(" ")[1].length === 2 &&
+          serviceClass[key].split(" ")[1].charAt(0) === "v"
+        ) {
+          methods.push({
+            pkgName: serviceClass[key].split(" ")[0],
+            version: serviceClass[key].split(" ")[1],
+            fileName: serviceClass[key].split(" ")[2],
+            functionName: key,
+            SDKFunctionName: serviceClass[key].split(" ")[3],
+            params: [],
+            returnType: null,
+            returnTypeName: null,
+            client: null
+          });
+        } else {
+          methods.push({
+            pkgName: serviceClass[key].split(" ")[0],
+            version: null,
+            fileName: serviceClass[key].split(" ")[1],
+            functionName: key,
+            SDKFunctionName: serviceClass[key].split(" ")[2],
+            params: [],
+            returnType: null,
+            returnTypeName: null,
+            client: null
+          });
+        }
+      });
+      if (methods[0].version) {
+        generateClientBasedCode(methods);
+      } else {
+        generateClassBasedCode(methods, data);
+      }
+      return [2 /*return*/];
     });
   });
 }

--- a/generator/generators/googleCloud/generator.ts
+++ b/generator/generators/googleCloud/generator.ts
@@ -49,6 +49,7 @@ const dummyAst = createSourceFile(
 );
 
 export function extractClassBasedSDKData(methods, sdkFiles): any {
+  const specifiedMethods = JSON.parse(JSON.stringify(methods));
   return new Promise(async (resolve, reject) => {
     try {
       let classes: ClassData[] = [];
@@ -154,8 +155,11 @@ export function extractClassBasedSDKData(methods, sdkFiles): any {
         classes,
         methods
       };
-
-      resolve(extractedData);
+      if (JSON.stringify(methods) === JSON.stringify(specifiedMethods)) {
+        reject(new Error("Data extraction unsuccessful"));
+      } else {
+        resolve(extractedData);
+      }
     } catch (error) {
       reject(error);
     }
@@ -163,6 +167,7 @@ export function extractClassBasedSDKData(methods, sdkFiles): any {
 }
 
 export function extractClientBasedSDKdata(methods, sdkFiles): any {
+  const specifiedMethods = JSON.parse(JSON.stringify(methods));
   return new Promise(async (resolve, reject) => {
     try {
       sdkFiles.map(sdkFile => {
@@ -203,7 +208,12 @@ export function extractClientBasedSDKdata(methods, sdkFiles): any {
           }
         });
       });
-      resolve(methods);
+
+      if (JSON.stringify(methods) === JSON.stringify(specifiedMethods)) {
+        reject(new Error("Data extraction unsuccessful"));
+      } else {
+        resolve(methods);
+      }
     } catch (error) {
       reject(error);
     }

--- a/generator/test/generators/aws/dummyData/invalidDataset_1/sdkFile.txt
+++ b/generator/test/generators/aws/dummyData/invalidDataset_1/sdkFile.txt
@@ -1,0 +1,380 @@
+import {Request} from '../lib/request';
+import {Response} from '../lib/response';
+import {AWSError} from '../lib/error';
+import {Service} from '../lib/service';
+import {ServiceConfigurationOptions} from '../lib/service';
+import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
+declare class SimpleDB extends Service {
+  /**
+   * Constructs a service object. This object has one method for each API operation.
+   */
+  constructor(options?: SimpleDB.Types.ClientConfiguration)
+  config: Config & SimpleDB.Types.ClientConfiguration;
+  /**
+   *  Performs multiple DeleteAttributes operations in a single call, which reduces round trips and latencies. This enables Amazon SimpleDB to optimize requests, which generally yields better throughput.    If you specify BatchDeleteAttributes without attributes or values, all the attributes for the item are deleted.   BatchDeleteAttributes is an idempotent operation; running it multiple times on the same item or attribute doesn't result in an error.   The BatchDeleteAttributes operation succeeds or fails in its entirety. There are no partial deletes. You can execute multiple BatchDeleteAttributes operations and other operations in parallel. However, large numbers of concurrent BatchDeleteAttributes calls can result in Service Unavailable (503) responses.   This operation is vulnerable to exceeding the maximum URL size when making a REST request using the HTTP GET method.   This operation does not support conditions using Expected.X.Name, Expected.X.Value, or Expected.X.Exists.    The following limitations are enforced for this operation:  1 MB request size 25 item limit per BatchDeleteAttributes operation  
+   */
+  batchDeleteAttributes(params: SimpleDB.Types.BatchDeleteAttributesRequest, callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  Performs multiple DeleteAttributes operations in a single call, which reduces round trips and latencies. This enables Amazon SimpleDB to optimize requests, which generally yields better throughput.    If you specify BatchDeleteAttributes without attributes or values, all the attributes for the item are deleted.   BatchDeleteAttributes is an idempotent operation; running it multiple times on the same item or attribute doesn't result in an error.   The BatchDeleteAttributes operation succeeds or fails in its entirety. There are no partial deletes. You can execute multiple BatchDeleteAttributes operations and other operations in parallel. However, large numbers of concurrent BatchDeleteAttributes calls can result in Service Unavailable (503) responses.   This operation is vulnerable to exceeding the maximum URL size when making a REST request using the HTTP GET method.   This operation does not support conditions using Expected.X.Name, Expected.X.Value, or Expected.X.Exists.    The following limitations are enforced for this operation:  1 MB request size 25 item limit per BatchDeleteAttributes operation  
+   */
+  batchDeleteAttributes(callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The BatchPutAttributes operation creates or replaces attributes within one or more items. By using this operation, the client can perform multiple PutAttribute operation with a single call. This helps yield savings in round trips and latencies, enabling Amazon SimpleDB to optimize requests and generally produce better throughput.   The client may specify the item name with the Item.X.ItemName parameter. The client may specify new attributes using a combination of the Item.X.Attribute.Y.Name and Item.X.Attribute.Y.Value parameters. The client may specify the first attribute for the first item using the parameters Item.0.Attribute.0.Name and Item.0.Attribute.0.Value, and for the second attribute for the first item by the parameters Item.0.Attribute.1.Name and Item.0.Attribute.1.Value, and so on.   Attributes are uniquely identified within an item by their name/value combination. For example, a single item can have the attributes { "first_name", "first_value" } and { "first_name", "second_value" }. However, it cannot have two attribute instances where both the Item.X.Attribute.Y.Name and Item.X.Attribute.Y.Value are the same.   Optionally, the requester can supply the Replace parameter for each individual value. Setting this value to true will cause the new attribute values to replace the existing attribute values. For example, if an item I has the attributes { 'a', '1' }, { 'b', '2'} and { 'b', '3' } and the requester does a BatchPutAttributes of {'I', 'b', '4' } with the Replace parameter set to true, the final attributes of the item will be { 'a', '1' } and { 'b', '4' }, replacing the previous values of the 'b' attribute with the new value.   You cannot specify an empty string as an item or as an attribute name. The BatchPutAttributes operation succeeds or fails in its entirety. There are no partial puts.   This operation is vulnerable to exceeding the maximum URL size when making a REST request using the HTTP GET method. This operation does not support conditions using Expected.X.Name, Expected.X.Value, or Expected.X.Exists.   You can execute multiple BatchPutAttributes operations and other operations in parallel. However, large numbers of concurrent BatchPutAttributes calls can result in Service Unavailable (503) responses.   The following limitations are enforced for this operation:  256 attribute name-value pairs per item 1 MB request size 1 billion attributes per domain 10 GB of total user data storage per domain 25 item limit per BatchPutAttributes operation  
+   */
+  batchPutAttributes(params: SimpleDB.Types.BatchPutAttributesRequest, callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The BatchPutAttributes operation creates or replaces attributes within one or more items. By using this operation, the client can perform multiple PutAttribute operation with a single call. This helps yield savings in round trips and latencies, enabling Amazon SimpleDB to optimize requests and generally produce better throughput.   The client may specify the item name with the Item.X.ItemName parameter. The client may specify new attributes using a combination of the Item.X.Attribute.Y.Name and Item.X.Attribute.Y.Value parameters. The client may specify the first attribute for the first item using the parameters Item.0.Attribute.0.Name and Item.0.Attribute.0.Value, and for the second attribute for the first item by the parameters Item.0.Attribute.1.Name and Item.0.Attribute.1.Value, and so on.   Attributes are uniquely identified within an item by their name/value combination. For example, a single item can have the attributes { "first_name", "first_value" } and { "first_name", "second_value" }. However, it cannot have two attribute instances where both the Item.X.Attribute.Y.Name and Item.X.Attribute.Y.Value are the same.   Optionally, the requester can supply the Replace parameter for each individual value. Setting this value to true will cause the new attribute values to replace the existing attribute values. For example, if an item I has the attributes { 'a', '1' }, { 'b', '2'} and { 'b', '3' } and the requester does a BatchPutAttributes of {'I', 'b', '4' } with the Replace parameter set to true, the final attributes of the item will be { 'a', '1' } and { 'b', '4' }, replacing the previous values of the 'b' attribute with the new value.   You cannot specify an empty string as an item or as an attribute name. The BatchPutAttributes operation succeeds or fails in its entirety. There are no partial puts.   This operation is vulnerable to exceeding the maximum URL size when making a REST request using the HTTP GET method. This operation does not support conditions using Expected.X.Name, Expected.X.Value, or Expected.X.Exists.   You can execute multiple BatchPutAttributes operations and other operations in parallel. However, large numbers of concurrent BatchPutAttributes calls can result in Service Unavailable (503) responses.   The following limitations are enforced for this operation:  256 attribute name-value pairs per item 1 MB request size 1 billion attributes per domain 10 GB of total user data storage per domain 25 item limit per BatchPutAttributes operation  
+   */
+  batchPutAttributes(callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The CreateDomain operation creates a new domain. The domain name should be unique among the domains associated with the Access Key ID provided in the request. The CreateDomain operation may take 10 or more seconds to complete.   CreateDomain is an idempotent operation; running it multiple times using the same domain name will not result in an error response.   The client can create up to 100 domains per account.   If the client requires additional domains, go to  http://aws.amazon.com/contact-us/simpledb-limit-request/. 
+   */
+  createDomain(params: SimpleDB.Types.CreateDomainRequest, callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The CreateDomain operation creates a new domain. The domain name should be unique among the domains associated with the Access Key ID provided in the request. The CreateDomain operation may take 10 or more seconds to complete.   CreateDomain is an idempotent operation; running it multiple times using the same domain name will not result in an error response.   The client can create up to 100 domains per account.   If the client requires additional domains, go to  http://aws.amazon.com/contact-us/simpledb-limit-request/. 
+   */
+  createDomain(callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  Deletes one or more attributes associated with an item. If all attributes of the item are deleted, the item is deleted.   If DeleteAttributes is called without being passed any attributes or values specified, all the attributes for the item are deleted.   DeleteAttributes is an idempotent operation; running it multiple times on the same item or attribute does not result in an error response.   Because Amazon SimpleDB makes multiple copies of item data and uses an eventual consistency update model, performing a GetAttributes or Select operation (read) immediately after a DeleteAttributes or PutAttributes operation (write) might not return updated item data. 
+   */
+  deleteAttributes(params: SimpleDB.Types.DeleteAttributesRequest, callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  Deletes one or more attributes associated with an item. If all attributes of the item are deleted, the item is deleted.   If DeleteAttributes is called without being passed any attributes or values specified, all the attributes for the item are deleted.   DeleteAttributes is an idempotent operation; running it multiple times on the same item or attribute does not result in an error response.   Because Amazon SimpleDB makes multiple copies of item data and uses an eventual consistency update model, performing a GetAttributes or Select operation (read) immediately after a DeleteAttributes or PutAttributes operation (write) might not return updated item data. 
+   */
+  deleteAttributes(callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The DeleteDomain operation deletes a domain. Any items (and their attributes) in the domain are deleted as well. The DeleteDomain operation might take 10 or more seconds to complete.   Running DeleteDomain on a domain that does not exist or running the function multiple times using the same domain name will not result in an error response. 
+   */
+  deleteDomain(params: SimpleDB.Types.DeleteDomainRequest, callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The DeleteDomain operation deletes a domain. Any items (and their attributes) in the domain are deleted as well. The DeleteDomain operation might take 10 or more seconds to complete.   Running DeleteDomain on a domain that does not exist or running the function multiple times using the same domain name will not result in an error response. 
+   */
+  deleteDomain(callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  Returns information about the domain, including when the domain was created, the number of items and attributes in the domain, and the size of the attribute names and values. 
+   */
+  domainMetadata(params: SimpleDB.Types.DomainMetadataRequest, callback?: (err: AWSError, data: SimpleDB.Types.DomainMetadataResult) => void): Request<SimpleDB.Types.DomainMetadataResult, AWSError>;
+  /**
+   *  Returns information about the domain, including when the domain was created, the number of items and attributes in the domain, and the size of the attribute names and values. 
+   */
+  domainMetadata(callback?: (err: AWSError, data: SimpleDB.Types.DomainMetadataResult) => void): Request<SimpleDB.Types.DomainMetadataResult, AWSError>;
+  /**
+   *  Returns all of the attributes associated with the specified item. Optionally, the attributes returned can be limited to one or more attributes by specifying an attribute name parameter.   If the item does not exist on the replica that was accessed for this operation, an empty set is returned. The system does not return an error as it cannot guarantee the item does not exist on other replicas.   If GetAttributes is called without being passed any attribute names, all the attributes for the item are returned. 
+   */
+  getAttributes(params: SimpleDB.Types.GetAttributesRequest, callback?: (err: AWSError, data: SimpleDB.Types.GetAttributesResult) => void): Request<SimpleDB.Types.GetAttributesResult, AWSError>;
+  /**
+   *  Returns all of the attributes associated with the specified item. Optionally, the attributes returned can be limited to one or more attributes by specifying an attribute name parameter.   If the item does not exist on the replica that was accessed for this operation, an empty set is returned. The system does not return an error as it cannot guarantee the item does not exist on other replicas.   If GetAttributes is called without being passed any attribute names, all the attributes for the item are returned. 
+   */
+  getAttributes(callback?: (err: AWSError, data: SimpleDB.Types.GetAttributesResult) => void): Request<SimpleDB.Types.GetAttributesResult, AWSError>;
+  /**
+   *  The ListDomains operation lists all domains associated with the Access Key ID. It returns domain names up to the limit set by MaxNumberOfDomains. A NextToken is returned if there are more than MaxNumberOfDomains domains. Calling ListDomains successive times with the NextToken provided by the operation returns up to MaxNumberOfDomains more domain names with each successive operation call. 
+   */
+  listDomains(params: SimpleDB.Types.ListDomainsRequest, callback?: (err: AWSError, data: SimpleDB.Types.ListDomainsResult) => void): Request<SimpleDB.Types.ListDomainsResult, AWSError>;
+  /**
+   *  The ListDomains operation lists all domains associated with the Access Key ID. It returns domain names up to the limit set by MaxNumberOfDomains. A NextToken is returned if there are more than MaxNumberOfDomains domains. Calling ListDomains successive times with the NextToken provided by the operation returns up to MaxNumberOfDomains more domain names with each successive operation call. 
+   */
+  listDomains(callback?: (err: AWSError, data: SimpleDB.Types.ListDomainsResult) => void): Request<SimpleDB.Types.ListDomainsResult, AWSError>;
+  /**
+   *  The PutAttributes operation creates or replaces attributes in an item. The client may specify new attributes using a combination of the Attribute.X.Name and Attribute.X.Value parameters. The client specifies the first attribute by the parameters Attribute.0.Name and Attribute.0.Value, the second attribute by the parameters Attribute.1.Name and Attribute.1.Value, and so on.   Attributes are uniquely identified in an item by their name/value combination. For example, a single item can have the attributes { "first_name", "first_value" } and { "first_name", second_value" }. However, it cannot have two attribute instances where both the Attribute.X.Name and Attribute.X.Value are the same.   Optionally, the requestor can supply the Replace parameter for each individual attribute. Setting this value to true causes the new attribute value to replace the existing attribute value(s). For example, if an item has the attributes { 'a', '1' }, { 'b', '2'} and { 'b', '3' } and the requestor calls PutAttributes using the attributes { 'b', '4' } with the Replace parameter set to true, the final attributes of the item are changed to { 'a', '1' } and { 'b', '4' }, which replaces the previous values of the 'b' attribute with the new value.   Using PutAttributes to replace attribute values that do not exist will not result in an error response.   You cannot specify an empty string as an attribute name.   Because Amazon SimpleDB makes multiple copies of client data and uses an eventual consistency update model, an immediate GetAttributes or Select operation (read) immediately after a PutAttributes or DeleteAttributes operation (write) might not return the updated data.   The following limitations are enforced for this operation:  256 total attribute name-value pairs per item One billion attributes per domain 10 GB of total user data storage per domain  
+   */
+  putAttributes(params: SimpleDB.Types.PutAttributesRequest, callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The PutAttributes operation creates or replaces attributes in an item. The client may specify new attributes using a combination of the Attribute.X.Name and Attribute.X.Value parameters. The client specifies the first attribute by the parameters Attribute.0.Name and Attribute.0.Value, the second attribute by the parameters Attribute.1.Name and Attribute.1.Value, and so on.   Attributes are uniquely identified in an item by their name/value combination. For example, a single item can have the attributes { "first_name", "first_value" } and { "first_name", second_value" }. However, it cannot have two attribute instances where both the Attribute.X.Name and Attribute.X.Value are the same.   Optionally, the requestor can supply the Replace parameter for each individual attribute. Setting this value to true causes the new attribute value to replace the existing attribute value(s). For example, if an item has the attributes { 'a', '1' }, { 'b', '2'} and { 'b', '3' } and the requestor calls PutAttributes using the attributes { 'b', '4' } with the Replace parameter set to true, the final attributes of the item are changed to { 'a', '1' } and { 'b', '4' }, which replaces the previous values of the 'b' attribute with the new value.   Using PutAttributes to replace attribute values that do not exist will not result in an error response.   You cannot specify an empty string as an attribute name.   Because Amazon SimpleDB makes multiple copies of client data and uses an eventual consistency update model, an immediate GetAttributes or Select operation (read) immediately after a PutAttributes or DeleteAttributes operation (write) might not return the updated data.   The following limitations are enforced for this operation:  256 total attribute name-value pairs per item One billion attributes per domain 10 GB of total user data storage per domain  
+   */
+  putAttributes(callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The Select operation returns a set of attributes for ItemNames that match the select expression. Select is similar to the standard SQL SELECT statement.   The total size of the response cannot exceed 1 MB in total size. Amazon SimpleDB automatically adjusts the number of items returned per page to enforce this limit. For example, if the client asks to retrieve 2500 items, but each individual item is 10 kB in size, the system returns 100 items and an appropriate NextToken so the client can access the next page of results.   For information on how to construct select expressions, see Using Select to Create Amazon SimpleDB Queries in the Developer Guide. 
+   */
+  select(params: SimpleDB.Types.SelectRequest, callback?: (err: AWSError, data: SimpleDB.Types.SelectResult) => void): Request<SimpleDB.Types.SelectResult, AWSError>;
+  /**
+   *  The Select operation returns a set of attributes for ItemNames that match the select expression. Select is similar to the standard SQL SELECT statement.   The total size of the response cannot exceed 1 MB in total size. Amazon SimpleDB automatically adjusts the number of items returned per page to enforce this limit. For example, if the client asks to retrieve 2500 items, but each individual item is 10 kB in size, the system returns 100 items and an appropriate NextToken so the client can access the next page of results.   For information on how to construct select expressions, see Using Select to Create Amazon SimpleDB Queries in the Developer Guide. 
+   */
+  select(callback?: (err: AWSError, data: SimpleDB.Types.SelectResult) => void): Request<SimpleDB.Types.SelectResult, AWSError>;
+}
+declare namespace SimpleDB {
+  export interface Attribute {
+    /**
+     * The name of the attribute.
+     */
+    Name: String;
+    /**
+     * 
+     */
+    AlternateNameEncoding?: String;
+    /**
+     * The value of the attribute.
+     */
+    Value: String;
+    /**
+     * 
+     */
+    AlternateValueEncoding?: String;
+  }
+  export type AttributeList = Attribute[];
+  export type AttributeNameList = String[];
+  export interface BatchDeleteAttributesRequest {
+    /**
+     * The name of the domain in which the attributes are being deleted.
+     */
+    DomainName: String;
+    /**
+     * A list of items on which to perform the operation.
+     */
+    Items: DeletableItemList;
+  }
+  export interface BatchPutAttributesRequest {
+    /**
+     * The name of the domain in which the attributes are being stored.
+     */
+    DomainName: String;
+    /**
+     * A list of items on which to perform the operation.
+     */
+    Items: ReplaceableItemList;
+  }
+  export type Boolean = boolean;
+  export interface CreateDomainRequest {
+    /**
+     * The name of the domain to create. The name can range between 3 and 255 characters and can contain the following characters: a-z, A-Z, 0-9, '_', '-', and '.'.
+     */
+    DomainName: String;
+  }
+  export interface DeletableAttribute {
+    /**
+     * The name of the attribute.
+     */
+    Name: String;
+    /**
+     * The value of the attribute.
+     */
+    Value?: String;
+  }
+  export type DeletableAttributeList = DeletableAttribute[];
+  export interface DeletableItem {
+    Name: String;
+    Attributes?: DeletableAttributeList;
+  }
+  export type DeletableItemList = DeletableItem[];
+  export interface DeleteAttributesRequest {
+    /**
+     * The name of the domain in which to perform the operation.
+     */
+    DomainName: String;
+    /**
+     * The name of the item. Similar to rows on a spreadsheet, items represent individual objects that contain one or more value-attribute pairs.
+     */
+    ItemName: String;
+    /**
+     * A list of Attributes. Similar to columns on a spreadsheet, attributes represent categories of data that can be assigned to items.
+     */
+    Attributes?: DeletableAttributeList;
+    /**
+     * The update condition which, if specified, determines whether the specified attributes will be deleted or not. The update condition must be satisfied in order for this request to be processed and the attributes to be deleted.
+     */
+    Expected?: UpdateCondition;
+  }
+  export interface DeleteDomainRequest {
+    /**
+     * The name of the domain to delete.
+     */
+    DomainName: String;
+  }
+  export interface DomainMetadataRequest {
+    /**
+     * The name of the domain for which to display the metadata of.
+     */
+    DomainName: String;
+  }
+  export interface DomainMetadataResult {
+    /**
+     * The number of all items in the domain.
+     */
+    ItemCount?: Integer;
+    /**
+     * The total size of all item names in the domain, in bytes.
+     */
+    ItemNamesSizeBytes?: Long;
+    /**
+     * The number of unique attribute names in the domain.
+     */
+    AttributeNameCount?: Integer;
+    /**
+     * The total size of all unique attribute names in the domain, in bytes.
+     */
+    AttributeNamesSizeBytes?: Long;
+    /**
+     * The number of all attribute name/value pairs in the domain.
+     */
+    AttributeValueCount?: Integer;
+    /**
+     * The total size of all attribute values in the domain, in bytes.
+     */
+    AttributeValuesSizeBytes?: Long;
+    /**
+     * The data and time when metadata was calculated, in Epoch (UNIX) seconds.
+     */
+    Timestamp?: Integer;
+  }
+  export type DomainNameList = String[];
+  export interface GetAttributesRequest {
+    /**
+     * The name of the domain in which to perform the operation.
+     */
+    DomainName: String;
+    /**
+     * The name of the item.
+     */
+    ItemName: String;
+    /**
+     * The names of the attributes.
+     */
+    AttributeNames?: AttributeNameList;
+    /**
+     * Determines whether or not strong consistency should be enforced when data is read from SimpleDB. If true, any data previously written to SimpleDB will be returned. Otherwise, results will be consistent eventually, and the client may not see data that was written immediately before your read.
+     */
+    ConsistentRead?: Boolean;
+  }
+  export interface GetAttributesResult {
+    /**
+     * The list of attributes returned by the operation.
+     */
+    Attributes?: AttributeList;
+  }
+  export type Integer = number;
+  export interface Item {
+    /**
+     * The name of the item.
+     */
+    Name: String;
+    /**
+     * 
+     */
+    AlternateNameEncoding?: String;
+    /**
+     * A list of attributes.
+     */
+    Attributes: AttributeList;
+  }
+  export type ItemList = Item[];
+  export interface ListDomainsRequest {
+    /**
+     * The maximum number of domain names you want returned. The range is 1 to 100. The default setting is 100.
+     */
+    MaxNumberOfDomains?: Integer;
+    /**
+     * A string informing Amazon SimpleDB where to start the next list of domain names.
+     */
+    NextToken?: String;
+  }
+  export interface ListDomainsResult {
+    /**
+     * A list of domain names that match the expression.
+     */
+    DomainNames?: DomainNameList;
+    /**
+     * An opaque token indicating that there are more domains than the specified MaxNumberOfDomains still available.
+     */
+    NextToken?: String;
+  }
+  export type Long = number;
+  export interface PutAttributesRequest {
+    /**
+     * The name of the domain in which to perform the operation.
+     */
+    DomainName: String;
+    /**
+     * The name of the item.
+     */
+    ItemName: String;
+    /**
+     * The list of attributes.
+     */
+    Attributes: ReplaceableAttributeList;
+    /**
+     * The update condition which, if specified, determines whether the specified attributes will be updated or not. The update condition must be satisfied in order for this request to be processed and the attributes to be updated.
+     */
+    Expected?: UpdateCondition;
+  }
+  export interface ReplaceableAttribute {
+    /**
+     * The name of the replaceable attribute.
+     */
+    Name: String;
+    /**
+     * The value of the replaceable attribute.
+     */
+    Value: String;
+    /**
+     * A flag specifying whether or not to replace the attribute/value pair or to add a new attribute/value pair. The default setting is false.
+     */
+    Replace?: Boolean;
+  }
+  export type ReplaceableAttributeList = ReplaceableAttribute[];
+  export interface ReplaceableItem {
+    /**
+     * The name of the replaceable item.
+     */
+    Name: String;
+    /**
+     * The list of attributes for a replaceable item.
+     */
+    Attributes: ReplaceableAttributeList;
+  }
+  export type ReplaceableItemList = ReplaceableItem[];
+  export interface SelectRequest {
+    /**
+     * The expression used to query the domain.
+     */
+    SelectExpression: String;
+    /**
+     * A string informing Amazon SimpleDB where to start the next list of ItemNames.
+     */
+    NextToken?: String;
+    /**
+     * Determines whether or not strong consistency should be enforced when data is read from SimpleDB. If true, any data previously written to SimpleDB will be returned. Otherwise, results will be consistent eventually, and the client may not see data that was written immediately before your read.
+     */
+    ConsistentRead?: Boolean;
+  }
+  export interface SelectResult {
+    /**
+     * A list of items that match the select expression.
+     */
+    Items?: ItemList;
+    /**
+     * An opaque token indicating that more items than MaxNumberOfItems were matched, the response size exceeded 1 megabyte, or the execution time exceeded 5 seconds.
+     */
+    NextToken?: String;
+  }
+  export type String = string;
+  export interface UpdateCondition {
+    /**
+     * The name of the attribute involved in the condition.
+     */
+    Name?: String;
+    /**
+     * The value of an attribute. This value can only be specified when the Exists parameter is equal to true.
+     */
+    Value?: String;
+    /**
+     * A value specifying whether or not the specified attribute must exist with the specified value in order for the update condition to be satisfied. Specify true if the attribute must exist for the update condition to be satisfied. Specify false if the attribute should not exist in order for the update condition to be satisfied.
+     */
+    Exists?: Boolean;
+  }
+  /**
+   * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
+   */
+  export type apiVersion = "2009-04-15"|"latest"|string;
+  export interface ClientApiVersions {
+    /**
+     * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
+     */
+    apiVersion?: apiVersion;
+  }
+  export type ClientConfiguration = ServiceConfigurationOptions & ClientApiVersions;
+  /**
+   * Contains interfaces for use with the SimpleDB client.
+   */
+  export import Types = SimpleDB;
+}
+export = SimpleDB;

--- a/generator/test/generators/aws/dummyData/invalidDataset_1/serviceClass.json
+++ b/generator/test/generators/aws/dummyData/invalidDataset_1/serviceClass.json
@@ -1,0 +1,11 @@
+{
+  "createCollection": "SimpleDB.d.ts createDomain",
+  "deleteCollection": "SimpleDB.d.ts",
+  "listCollections": "SimpleDB.d.ts listDomains",
+  "batchDelete": "SimpleDB.d.ts batchDeleteAttributes",
+  "batchWrite": "SimpleDB.d.ts batchPutAttributes",
+  "query": "SimpleDB.d.ts select",
+  "setAttribute": "SimpleDB.d.ts putAttributes",
+  "deleteAttribute": "SimpleDB.d.ts deleteAttributes",
+  "getAttributes": "SimpleDB.d.ts getAttributes"
+}

--- a/generator/test/generators/aws/dummyData/invalidDataset_2/sdkFile.txt
+++ b/generator/test/generators/aws/dummyData/invalidDataset_2/sdkFile.txt
@@ -1,0 +1,296 @@
+import {Request} from '../lib/request';
+import {Response} from '../lib/response';
+import {AWSError} from '../lib/error';
+import {Service} from '../lib/service';
+import {ServiceConfigurationOptions} from '../lib/service';
+import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
+declare class SimpleDB extends Service {
+  
+}
+declare namespace SimpleDB {
+  export interface Attribute {
+    /**
+     * The name of the attribute.
+     */
+    Name: String;
+    /**
+     * 
+     */
+    AlternateNameEncoding?: String;
+    /**
+     * The value of the attribute.
+     */
+    Value: String;
+    /**
+     * 
+     */
+    AlternateValueEncoding?: String;
+  }
+  export type AttributeList = Attribute[];
+  export type AttributeNameList = String[];
+  export interface BatchDeleteAttributesRequest {
+    /**
+     * The name of the domain in which the attributes are being deleted.
+     */
+    DomainName: String;
+    /**
+     * A list of items on which to perform the operation.
+     */
+    Items: DeletableItemList;
+  }
+  export interface BatchPutAttributesRequest {
+    /**
+     * The name of the domain in which the attributes are being stored.
+     */
+    DomainName: String;
+    /**
+     * A list of items on which to perform the operation.
+     */
+    Items: ReplaceableItemList;
+  }
+  export type Boolean = boolean;
+  export interface CreateDomainRequest {
+    /**
+     * The name of the domain to create. The name can range between 3 and 255 characters and can contain the following characters: a-z, A-Z, 0-9, '_', '-', and '.'.
+     */
+    DomainName: String;
+  }
+  export interface DeletableAttribute {
+    /**
+     * The name of the attribute.
+     */
+    Name: String;
+    /**
+     * The value of the attribute.
+     */
+    Value?: String;
+  }
+  export type DeletableAttributeList = DeletableAttribute[];
+  export interface DeletableItem {
+    Name: String;
+    Attributes?: DeletableAttributeList;
+  }
+  export type DeletableItemList = DeletableItem[];
+  export interface DeleteAttributesRequest {
+    /**
+     * The name of the domain in which to perform the operation.
+     */
+    DomainName: String;
+    /**
+     * The name of the item. Similar to rows on a spreadsheet, items represent individual objects that contain one or more value-attribute pairs.
+     */
+    ItemName: String;
+    /**
+     * A list of Attributes. Similar to columns on a spreadsheet, attributes represent categories of data that can be assigned to items.
+     */
+    Attributes?: DeletableAttributeList;
+    /**
+     * The update condition which, if specified, determines whether the specified attributes will be deleted or not. The update condition must be satisfied in order for this request to be processed and the attributes to be deleted.
+     */
+    Expected?: UpdateCondition;
+  }
+  export interface DeleteDomainRequest {
+    /**
+     * The name of the domain to delete.
+     */
+    DomainName: String;
+  }
+  export interface DomainMetadataRequest {
+    /**
+     * The name of the domain for which to display the metadata of.
+     */
+    DomainName: String;
+  }
+  export interface DomainMetadataResult {
+    /**
+     * The number of all items in the domain.
+     */
+    ItemCount?: Integer;
+    /**
+     * The total size of all item names in the domain, in bytes.
+     */
+    ItemNamesSizeBytes?: Long;
+    /**
+     * The number of unique attribute names in the domain.
+     */
+    AttributeNameCount?: Integer;
+    /**
+     * The total size of all unique attribute names in the domain, in bytes.
+     */
+    AttributeNamesSizeBytes?: Long;
+    /**
+     * The number of all attribute name/value pairs in the domain.
+     */
+    AttributeValueCount?: Integer;
+    /**
+     * The total size of all attribute values in the domain, in bytes.
+     */
+    AttributeValuesSizeBytes?: Long;
+    /**
+     * The data and time when metadata was calculated, in Epoch (UNIX) seconds.
+     */
+    Timestamp?: Integer;
+  }
+  export type DomainNameList = String[];
+  export interface GetAttributesRequest {
+    /**
+     * The name of the domain in which to perform the operation.
+     */
+    DomainName: String;
+    /**
+     * The name of the item.
+     */
+    ItemName: String;
+    /**
+     * The names of the attributes.
+     */
+    AttributeNames?: AttributeNameList;
+    /**
+     * Determines whether or not strong consistency should be enforced when data is read from SimpleDB. If true, any data previously written to SimpleDB will be returned. Otherwise, results will be consistent eventually, and the client may not see data that was written immediately before your read.
+     */
+    ConsistentRead?: Boolean;
+  }
+  export interface GetAttributesResult {
+    /**
+     * The list of attributes returned by the operation.
+     */
+    Attributes?: AttributeList;
+  }
+  export type Integer = number;
+  export interface Item {
+    /**
+     * The name of the item.
+     */
+    Name: String;
+    /**
+     * 
+     */
+    AlternateNameEncoding?: String;
+    /**
+     * A list of attributes.
+     */
+    Attributes: AttributeList;
+  }
+  export type ItemList = Item[];
+  export interface ListDomainsRequest {
+    /**
+     * The maximum number of domain names you want returned. The range is 1 to 100. The default setting is 100.
+     */
+    MaxNumberOfDomains?: Integer;
+    /**
+     * A string informing Amazon SimpleDB where to start the next list of domain names.
+     */
+    NextToken?: String;
+  }
+  export interface ListDomainsResult {
+    /**
+     * A list of domain names that match the expression.
+     */
+    DomainNames?: DomainNameList;
+    /**
+     * An opaque token indicating that there are more domains than the specified MaxNumberOfDomains still available.
+     */
+    NextToken?: String;
+  }
+  export type Long = number;
+  export interface PutAttributesRequest {
+    /**
+     * The name of the domain in which to perform the operation.
+     */
+    DomainName: String;
+    /**
+     * The name of the item.
+     */
+    ItemName: String;
+    /**
+     * The list of attributes.
+     */
+    Attributes: ReplaceableAttributeList;
+    /**
+     * The update condition which, if specified, determines whether the specified attributes will be updated or not. The update condition must be satisfied in order for this request to be processed and the attributes to be updated.
+     */
+    Expected?: UpdateCondition;
+  }
+  export interface ReplaceableAttribute {
+    /**
+     * The name of the replaceable attribute.
+     */
+    Name: String;
+    /**
+     * The value of the replaceable attribute.
+     */
+    Value: String;
+    /**
+     * A flag specifying whether or not to replace the attribute/value pair or to add a new attribute/value pair. The default setting is false.
+     */
+    Replace?: Boolean;
+  }
+  export type ReplaceableAttributeList = ReplaceableAttribute[];
+  export interface ReplaceableItem {
+    /**
+     * The name of the replaceable item.
+     */
+    Name: String;
+    /**
+     * The list of attributes for a replaceable item.
+     */
+    Attributes: ReplaceableAttributeList;
+  }
+  export type ReplaceableItemList = ReplaceableItem[];
+  export interface SelectRequest {
+    /**
+     * The expression used to query the domain.
+     */
+    SelectExpression: String;
+    /**
+     * A string informing Amazon SimpleDB where to start the next list of ItemNames.
+     */
+    NextToken?: String;
+    /**
+     * Determines whether or not strong consistency should be enforced when data is read from SimpleDB. If true, any data previously written to SimpleDB will be returned. Otherwise, results will be consistent eventually, and the client may not see data that was written immediately before your read.
+     */
+    ConsistentRead?: Boolean;
+  }
+  export interface SelectResult {
+    /**
+     * A list of items that match the select expression.
+     */
+    Items?: ItemList;
+    /**
+     * An opaque token indicating that more items than MaxNumberOfItems were matched, the response size exceeded 1 megabyte, or the execution time exceeded 5 seconds.
+     */
+    NextToken?: String;
+  }
+  export type String = string;
+  export interface UpdateCondition {
+    /**
+     * The name of the attribute involved in the condition.
+     */
+    Name?: String;
+    /**
+     * The value of an attribute. This value can only be specified when the Exists parameter is equal to true.
+     */
+    Value?: String;
+    /**
+     * A value specifying whether or not the specified attribute must exist with the specified value in order for the update condition to be satisfied. Specify true if the attribute must exist for the update condition to be satisfied. Specify false if the attribute should not exist in order for the update condition to be satisfied.
+     */
+    Exists?: Boolean;
+  }
+  /**
+   * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
+   */
+  export type apiVersion = "2009-04-15"|"latest"|string;
+  export interface ClientApiVersions {
+    /**
+     * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
+     */
+    apiVersion?: apiVersion;
+  }
+  export type ClientConfiguration = ServiceConfigurationOptions & ClientApiVersions;
+  /**
+   * Contains interfaces for use with the SimpleDB client.
+   */
+  export import Types = SimpleDB;
+}
+export = SimpleDB;

--- a/generator/test/generators/aws/dummyData/invalidDataset_2/serviceClass.json
+++ b/generator/test/generators/aws/dummyData/invalidDataset_2/serviceClass.json
@@ -1,0 +1,11 @@
+{
+  "createCollection": "SimpleDB.d.ts createDomain",
+  "deleteCollection": "SimpleDB.d.ts deleteDomain",
+  "listCollections": "SimpleDB.d.ts listDomains",
+  "batchDelete": "SimpleDB.d.ts batchDeleteAttributes",
+  "batchWrite": "SimpleDB.d.ts batchPutAttributes",
+  "query": "SimpleDB.d.ts select",
+  "setAttribute": "SimpleDB.d.ts putAttributes",
+  "deleteAttribute": "SimpleDB.d.ts deleteAttributes",
+  "getAttributes": "SimpleDB.d.ts getAttributes"
+}

--- a/generator/test/generators/aws/dummyData/validDataset/sdkFile.txt
+++ b/generator/test/generators/aws/dummyData/validDataset/sdkFile.txt
@@ -1,0 +1,380 @@
+import {Request} from '../lib/request';
+import {Response} from '../lib/response';
+import {AWSError} from '../lib/error';
+import {Service} from '../lib/service';
+import {ServiceConfigurationOptions} from '../lib/service';
+import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
+declare class SimpleDB extends Service {
+  /**
+   * Constructs a service object. This object has one method for each API operation.
+   */
+  constructor(options?: SimpleDB.Types.ClientConfiguration)
+  config: Config & SimpleDB.Types.ClientConfiguration;
+  /**
+   *  Performs multiple DeleteAttributes operations in a single call, which reduces round trips and latencies. This enables Amazon SimpleDB to optimize requests, which generally yields better throughput.    If you specify BatchDeleteAttributes without attributes or values, all the attributes for the item are deleted.   BatchDeleteAttributes is an idempotent operation; running it multiple times on the same item or attribute doesn't result in an error.   The BatchDeleteAttributes operation succeeds or fails in its entirety. There are no partial deletes. You can execute multiple BatchDeleteAttributes operations and other operations in parallel. However, large numbers of concurrent BatchDeleteAttributes calls can result in Service Unavailable (503) responses.   This operation is vulnerable to exceeding the maximum URL size when making a REST request using the HTTP GET method.   This operation does not support conditions using Expected.X.Name, Expected.X.Value, or Expected.X.Exists.    The following limitations are enforced for this operation:  1 MB request size 25 item limit per BatchDeleteAttributes operation  
+   */
+  batchDeleteAttributes(params: SimpleDB.Types.BatchDeleteAttributesRequest, callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  Performs multiple DeleteAttributes operations in a single call, which reduces round trips and latencies. This enables Amazon SimpleDB to optimize requests, which generally yields better throughput.    If you specify BatchDeleteAttributes without attributes or values, all the attributes for the item are deleted.   BatchDeleteAttributes is an idempotent operation; running it multiple times on the same item or attribute doesn't result in an error.   The BatchDeleteAttributes operation succeeds or fails in its entirety. There are no partial deletes. You can execute multiple BatchDeleteAttributes operations and other operations in parallel. However, large numbers of concurrent BatchDeleteAttributes calls can result in Service Unavailable (503) responses.   This operation is vulnerable to exceeding the maximum URL size when making a REST request using the HTTP GET method.   This operation does not support conditions using Expected.X.Name, Expected.X.Value, or Expected.X.Exists.    The following limitations are enforced for this operation:  1 MB request size 25 item limit per BatchDeleteAttributes operation  
+   */
+  batchDeleteAttributes(callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The BatchPutAttributes operation creates or replaces attributes within one or more items. By using this operation, the client can perform multiple PutAttribute operation with a single call. This helps yield savings in round trips and latencies, enabling Amazon SimpleDB to optimize requests and generally produce better throughput.   The client may specify the item name with the Item.X.ItemName parameter. The client may specify new attributes using a combination of the Item.X.Attribute.Y.Name and Item.X.Attribute.Y.Value parameters. The client may specify the first attribute for the first item using the parameters Item.0.Attribute.0.Name and Item.0.Attribute.0.Value, and for the second attribute for the first item by the parameters Item.0.Attribute.1.Name and Item.0.Attribute.1.Value, and so on.   Attributes are uniquely identified within an item by their name/value combination. For example, a single item can have the attributes { "first_name", "first_value" } and { "first_name", "second_value" }. However, it cannot have two attribute instances where both the Item.X.Attribute.Y.Name and Item.X.Attribute.Y.Value are the same.   Optionally, the requester can supply the Replace parameter for each individual value. Setting this value to true will cause the new attribute values to replace the existing attribute values. For example, if an item I has the attributes { 'a', '1' }, { 'b', '2'} and { 'b', '3' } and the requester does a BatchPutAttributes of {'I', 'b', '4' } with the Replace parameter set to true, the final attributes of the item will be { 'a', '1' } and { 'b', '4' }, replacing the previous values of the 'b' attribute with the new value.   You cannot specify an empty string as an item or as an attribute name. The BatchPutAttributes operation succeeds or fails in its entirety. There are no partial puts.   This operation is vulnerable to exceeding the maximum URL size when making a REST request using the HTTP GET method. This operation does not support conditions using Expected.X.Name, Expected.X.Value, or Expected.X.Exists.   You can execute multiple BatchPutAttributes operations and other operations in parallel. However, large numbers of concurrent BatchPutAttributes calls can result in Service Unavailable (503) responses.   The following limitations are enforced for this operation:  256 attribute name-value pairs per item 1 MB request size 1 billion attributes per domain 10 GB of total user data storage per domain 25 item limit per BatchPutAttributes operation  
+   */
+  batchPutAttributes(params: SimpleDB.Types.BatchPutAttributesRequest, callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The BatchPutAttributes operation creates or replaces attributes within one or more items. By using this operation, the client can perform multiple PutAttribute operation with a single call. This helps yield savings in round trips and latencies, enabling Amazon SimpleDB to optimize requests and generally produce better throughput.   The client may specify the item name with the Item.X.ItemName parameter. The client may specify new attributes using a combination of the Item.X.Attribute.Y.Name and Item.X.Attribute.Y.Value parameters. The client may specify the first attribute for the first item using the parameters Item.0.Attribute.0.Name and Item.0.Attribute.0.Value, and for the second attribute for the first item by the parameters Item.0.Attribute.1.Name and Item.0.Attribute.1.Value, and so on.   Attributes are uniquely identified within an item by their name/value combination. For example, a single item can have the attributes { "first_name", "first_value" } and { "first_name", "second_value" }. However, it cannot have two attribute instances where both the Item.X.Attribute.Y.Name and Item.X.Attribute.Y.Value are the same.   Optionally, the requester can supply the Replace parameter for each individual value. Setting this value to true will cause the new attribute values to replace the existing attribute values. For example, if an item I has the attributes { 'a', '1' }, { 'b', '2'} and { 'b', '3' } and the requester does a BatchPutAttributes of {'I', 'b', '4' } with the Replace parameter set to true, the final attributes of the item will be { 'a', '1' } and { 'b', '4' }, replacing the previous values of the 'b' attribute with the new value.   You cannot specify an empty string as an item or as an attribute name. The BatchPutAttributes operation succeeds or fails in its entirety. There are no partial puts.   This operation is vulnerable to exceeding the maximum URL size when making a REST request using the HTTP GET method. This operation does not support conditions using Expected.X.Name, Expected.X.Value, or Expected.X.Exists.   You can execute multiple BatchPutAttributes operations and other operations in parallel. However, large numbers of concurrent BatchPutAttributes calls can result in Service Unavailable (503) responses.   The following limitations are enforced for this operation:  256 attribute name-value pairs per item 1 MB request size 1 billion attributes per domain 10 GB of total user data storage per domain 25 item limit per BatchPutAttributes operation  
+   */
+  batchPutAttributes(callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The CreateDomain operation creates a new domain. The domain name should be unique among the domains associated with the Access Key ID provided in the request. The CreateDomain operation may take 10 or more seconds to complete.   CreateDomain is an idempotent operation; running it multiple times using the same domain name will not result in an error response.   The client can create up to 100 domains per account.   If the client requires additional domains, go to  http://aws.amazon.com/contact-us/simpledb-limit-request/. 
+   */
+  createDomain(params: SimpleDB.Types.CreateDomainRequest, callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The CreateDomain operation creates a new domain. The domain name should be unique among the domains associated with the Access Key ID provided in the request. The CreateDomain operation may take 10 or more seconds to complete.   CreateDomain is an idempotent operation; running it multiple times using the same domain name will not result in an error response.   The client can create up to 100 domains per account.   If the client requires additional domains, go to  http://aws.amazon.com/contact-us/simpledb-limit-request/. 
+   */
+  createDomain(callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  Deletes one or more attributes associated with an item. If all attributes of the item are deleted, the item is deleted.   If DeleteAttributes is called without being passed any attributes or values specified, all the attributes for the item are deleted.   DeleteAttributes is an idempotent operation; running it multiple times on the same item or attribute does not result in an error response.   Because Amazon SimpleDB makes multiple copies of item data and uses an eventual consistency update model, performing a GetAttributes or Select operation (read) immediately after a DeleteAttributes or PutAttributes operation (write) might not return updated item data. 
+   */
+  deleteAttributes(params: SimpleDB.Types.DeleteAttributesRequest, callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  Deletes one or more attributes associated with an item. If all attributes of the item are deleted, the item is deleted.   If DeleteAttributes is called without being passed any attributes or values specified, all the attributes for the item are deleted.   DeleteAttributes is an idempotent operation; running it multiple times on the same item or attribute does not result in an error response.   Because Amazon SimpleDB makes multiple copies of item data and uses an eventual consistency update model, performing a GetAttributes or Select operation (read) immediately after a DeleteAttributes or PutAttributes operation (write) might not return updated item data. 
+   */
+  deleteAttributes(callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The DeleteDomain operation deletes a domain. Any items (and their attributes) in the domain are deleted as well. The DeleteDomain operation might take 10 or more seconds to complete.   Running DeleteDomain on a domain that does not exist or running the function multiple times using the same domain name will not result in an error response. 
+   */
+  deleteDomain(params: SimpleDB.Types.DeleteDomainRequest, callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The DeleteDomain operation deletes a domain. Any items (and their attributes) in the domain are deleted as well. The DeleteDomain operation might take 10 or more seconds to complete.   Running DeleteDomain on a domain that does not exist or running the function multiple times using the same domain name will not result in an error response. 
+   */
+  deleteDomain(callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  Returns information about the domain, including when the domain was created, the number of items and attributes in the domain, and the size of the attribute names and values. 
+   */
+  domainMetadata(params: SimpleDB.Types.DomainMetadataRequest, callback?: (err: AWSError, data: SimpleDB.Types.DomainMetadataResult) => void): Request<SimpleDB.Types.DomainMetadataResult, AWSError>;
+  /**
+   *  Returns information about the domain, including when the domain was created, the number of items and attributes in the domain, and the size of the attribute names and values. 
+   */
+  domainMetadata(callback?: (err: AWSError, data: SimpleDB.Types.DomainMetadataResult) => void): Request<SimpleDB.Types.DomainMetadataResult, AWSError>;
+  /**
+   *  Returns all of the attributes associated with the specified item. Optionally, the attributes returned can be limited to one or more attributes by specifying an attribute name parameter.   If the item does not exist on the replica that was accessed for this operation, an empty set is returned. The system does not return an error as it cannot guarantee the item does not exist on other replicas.   If GetAttributes is called without being passed any attribute names, all the attributes for the item are returned. 
+   */
+  getAttributes(params: SimpleDB.Types.GetAttributesRequest, callback?: (err: AWSError, data: SimpleDB.Types.GetAttributesResult) => void): Request<SimpleDB.Types.GetAttributesResult, AWSError>;
+  /**
+   *  Returns all of the attributes associated with the specified item. Optionally, the attributes returned can be limited to one or more attributes by specifying an attribute name parameter.   If the item does not exist on the replica that was accessed for this operation, an empty set is returned. The system does not return an error as it cannot guarantee the item does not exist on other replicas.   If GetAttributes is called without being passed any attribute names, all the attributes for the item are returned. 
+   */
+  getAttributes(callback?: (err: AWSError, data: SimpleDB.Types.GetAttributesResult) => void): Request<SimpleDB.Types.GetAttributesResult, AWSError>;
+  /**
+   *  The ListDomains operation lists all domains associated with the Access Key ID. It returns domain names up to the limit set by MaxNumberOfDomains. A NextToken is returned if there are more than MaxNumberOfDomains domains. Calling ListDomains successive times with the NextToken provided by the operation returns up to MaxNumberOfDomains more domain names with each successive operation call. 
+   */
+  listDomains(params: SimpleDB.Types.ListDomainsRequest, callback?: (err: AWSError, data: SimpleDB.Types.ListDomainsResult) => void): Request<SimpleDB.Types.ListDomainsResult, AWSError>;
+  /**
+   *  The ListDomains operation lists all domains associated with the Access Key ID. It returns domain names up to the limit set by MaxNumberOfDomains. A NextToken is returned if there are more than MaxNumberOfDomains domains. Calling ListDomains successive times with the NextToken provided by the operation returns up to MaxNumberOfDomains more domain names with each successive operation call. 
+   */
+  listDomains(callback?: (err: AWSError, data: SimpleDB.Types.ListDomainsResult) => void): Request<SimpleDB.Types.ListDomainsResult, AWSError>;
+  /**
+   *  The PutAttributes operation creates or replaces attributes in an item. The client may specify new attributes using a combination of the Attribute.X.Name and Attribute.X.Value parameters. The client specifies the first attribute by the parameters Attribute.0.Name and Attribute.0.Value, the second attribute by the parameters Attribute.1.Name and Attribute.1.Value, and so on.   Attributes are uniquely identified in an item by their name/value combination. For example, a single item can have the attributes { "first_name", "first_value" } and { "first_name", second_value" }. However, it cannot have two attribute instances where both the Attribute.X.Name and Attribute.X.Value are the same.   Optionally, the requestor can supply the Replace parameter for each individual attribute. Setting this value to true causes the new attribute value to replace the existing attribute value(s). For example, if an item has the attributes { 'a', '1' }, { 'b', '2'} and { 'b', '3' } and the requestor calls PutAttributes using the attributes { 'b', '4' } with the Replace parameter set to true, the final attributes of the item are changed to { 'a', '1' } and { 'b', '4' }, which replaces the previous values of the 'b' attribute with the new value.   Using PutAttributes to replace attribute values that do not exist will not result in an error response.   You cannot specify an empty string as an attribute name.   Because Amazon SimpleDB makes multiple copies of client data and uses an eventual consistency update model, an immediate GetAttributes or Select operation (read) immediately after a PutAttributes or DeleteAttributes operation (write) might not return the updated data.   The following limitations are enforced for this operation:  256 total attribute name-value pairs per item One billion attributes per domain 10 GB of total user data storage per domain  
+   */
+  putAttributes(params: SimpleDB.Types.PutAttributesRequest, callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The PutAttributes operation creates or replaces attributes in an item. The client may specify new attributes using a combination of the Attribute.X.Name and Attribute.X.Value parameters. The client specifies the first attribute by the parameters Attribute.0.Name and Attribute.0.Value, the second attribute by the parameters Attribute.1.Name and Attribute.1.Value, and so on.   Attributes are uniquely identified in an item by their name/value combination. For example, a single item can have the attributes { "first_name", "first_value" } and { "first_name", second_value" }. However, it cannot have two attribute instances where both the Attribute.X.Name and Attribute.X.Value are the same.   Optionally, the requestor can supply the Replace parameter for each individual attribute. Setting this value to true causes the new attribute value to replace the existing attribute value(s). For example, if an item has the attributes { 'a', '1' }, { 'b', '2'} and { 'b', '3' } and the requestor calls PutAttributes using the attributes { 'b', '4' } with the Replace parameter set to true, the final attributes of the item are changed to { 'a', '1' } and { 'b', '4' }, which replaces the previous values of the 'b' attribute with the new value.   Using PutAttributes to replace attribute values that do not exist will not result in an error response.   You cannot specify an empty string as an attribute name.   Because Amazon SimpleDB makes multiple copies of client data and uses an eventual consistency update model, an immediate GetAttributes or Select operation (read) immediately after a PutAttributes or DeleteAttributes operation (write) might not return the updated data.   The following limitations are enforced for this operation:  256 total attribute name-value pairs per item One billion attributes per domain 10 GB of total user data storage per domain  
+   */
+  putAttributes(callback?: (err: AWSError, data: {}) => void): Request<{}, AWSError>;
+  /**
+   *  The Select operation returns a set of attributes for ItemNames that match the select expression. Select is similar to the standard SQL SELECT statement.   The total size of the response cannot exceed 1 MB in total size. Amazon SimpleDB automatically adjusts the number of items returned per page to enforce this limit. For example, if the client asks to retrieve 2500 items, but each individual item is 10 kB in size, the system returns 100 items and an appropriate NextToken so the client can access the next page of results.   For information on how to construct select expressions, see Using Select to Create Amazon SimpleDB Queries in the Developer Guide. 
+   */
+  select(params: SimpleDB.Types.SelectRequest, callback?: (err: AWSError, data: SimpleDB.Types.SelectResult) => void): Request<SimpleDB.Types.SelectResult, AWSError>;
+  /**
+   *  The Select operation returns a set of attributes for ItemNames that match the select expression. Select is similar to the standard SQL SELECT statement.   The total size of the response cannot exceed 1 MB in total size. Amazon SimpleDB automatically adjusts the number of items returned per page to enforce this limit. For example, if the client asks to retrieve 2500 items, but each individual item is 10 kB in size, the system returns 100 items and an appropriate NextToken so the client can access the next page of results.   For information on how to construct select expressions, see Using Select to Create Amazon SimpleDB Queries in the Developer Guide. 
+   */
+  select(callback?: (err: AWSError, data: SimpleDB.Types.SelectResult) => void): Request<SimpleDB.Types.SelectResult, AWSError>;
+}
+declare namespace SimpleDB {
+  export interface Attribute {
+    /**
+     * The name of the attribute.
+     */
+    Name: String;
+    /**
+     * 
+     */
+    AlternateNameEncoding?: String;
+    /**
+     * The value of the attribute.
+     */
+    Value: String;
+    /**
+     * 
+     */
+    AlternateValueEncoding?: String;
+  }
+  export type AttributeList = Attribute[];
+  export type AttributeNameList = String[];
+  export interface BatchDeleteAttributesRequest {
+    /**
+     * The name of the domain in which the attributes are being deleted.
+     */
+    DomainName: String;
+    /**
+     * A list of items on which to perform the operation.
+     */
+    Items: DeletableItemList;
+  }
+  export interface BatchPutAttributesRequest {
+    /**
+     * The name of the domain in which the attributes are being stored.
+     */
+    DomainName: String;
+    /**
+     * A list of items on which to perform the operation.
+     */
+    Items: ReplaceableItemList;
+  }
+  export type Boolean = boolean;
+  export interface CreateDomainRequest {
+    /**
+     * The name of the domain to create. The name can range between 3 and 255 characters and can contain the following characters: a-z, A-Z, 0-9, '_', '-', and '.'.
+     */
+    DomainName: String;
+  }
+  export interface DeletableAttribute {
+    /**
+     * The name of the attribute.
+     */
+    Name: String;
+    /**
+     * The value of the attribute.
+     */
+    Value?: String;
+  }
+  export type DeletableAttributeList = DeletableAttribute[];
+  export interface DeletableItem {
+    Name: String;
+    Attributes?: DeletableAttributeList;
+  }
+  export type DeletableItemList = DeletableItem[];
+  export interface DeleteAttributesRequest {
+    /**
+     * The name of the domain in which to perform the operation.
+     */
+    DomainName: String;
+    /**
+     * The name of the item. Similar to rows on a spreadsheet, items represent individual objects that contain one or more value-attribute pairs.
+     */
+    ItemName: String;
+    /**
+     * A list of Attributes. Similar to columns on a spreadsheet, attributes represent categories of data that can be assigned to items.
+     */
+    Attributes?: DeletableAttributeList;
+    /**
+     * The update condition which, if specified, determines whether the specified attributes will be deleted or not. The update condition must be satisfied in order for this request to be processed and the attributes to be deleted.
+     */
+    Expected?: UpdateCondition;
+  }
+  export interface DeleteDomainRequest {
+    /**
+     * The name of the domain to delete.
+     */
+    DomainName: String;
+  }
+  export interface DomainMetadataRequest {
+    /**
+     * The name of the domain for which to display the metadata of.
+     */
+    DomainName: String;
+  }
+  export interface DomainMetadataResult {
+    /**
+     * The number of all items in the domain.
+     */
+    ItemCount?: Integer;
+    /**
+     * The total size of all item names in the domain, in bytes.
+     */
+    ItemNamesSizeBytes?: Long;
+    /**
+     * The number of unique attribute names in the domain.
+     */
+    AttributeNameCount?: Integer;
+    /**
+     * The total size of all unique attribute names in the domain, in bytes.
+     */
+    AttributeNamesSizeBytes?: Long;
+    /**
+     * The number of all attribute name/value pairs in the domain.
+     */
+    AttributeValueCount?: Integer;
+    /**
+     * The total size of all attribute values in the domain, in bytes.
+     */
+    AttributeValuesSizeBytes?: Long;
+    /**
+     * The data and time when metadata was calculated, in Epoch (UNIX) seconds.
+     */
+    Timestamp?: Integer;
+  }
+  export type DomainNameList = String[];
+  export interface GetAttributesRequest {
+    /**
+     * The name of the domain in which to perform the operation.
+     */
+    DomainName: String;
+    /**
+     * The name of the item.
+     */
+    ItemName: String;
+    /**
+     * The names of the attributes.
+     */
+    AttributeNames?: AttributeNameList;
+    /**
+     * Determines whether or not strong consistency should be enforced when data is read from SimpleDB. If true, any data previously written to SimpleDB will be returned. Otherwise, results will be consistent eventually, and the client may not see data that was written immediately before your read.
+     */
+    ConsistentRead?: Boolean;
+  }
+  export interface GetAttributesResult {
+    /**
+     * The list of attributes returned by the operation.
+     */
+    Attributes?: AttributeList;
+  }
+  export type Integer = number;
+  export interface Item {
+    /**
+     * The name of the item.
+     */
+    Name: String;
+    /**
+     * 
+     */
+    AlternateNameEncoding?: String;
+    /**
+     * A list of attributes.
+     */
+    Attributes: AttributeList;
+  }
+  export type ItemList = Item[];
+  export interface ListDomainsRequest {
+    /**
+     * The maximum number of domain names you want returned. The range is 1 to 100. The default setting is 100.
+     */
+    MaxNumberOfDomains?: Integer;
+    /**
+     * A string informing Amazon SimpleDB where to start the next list of domain names.
+     */
+    NextToken?: String;
+  }
+  export interface ListDomainsResult {
+    /**
+     * A list of domain names that match the expression.
+     */
+    DomainNames?: DomainNameList;
+    /**
+     * An opaque token indicating that there are more domains than the specified MaxNumberOfDomains still available.
+     */
+    NextToken?: String;
+  }
+  export type Long = number;
+  export interface PutAttributesRequest {
+    /**
+     * The name of the domain in which to perform the operation.
+     */
+    DomainName: String;
+    /**
+     * The name of the item.
+     */
+    ItemName: String;
+    /**
+     * The list of attributes.
+     */
+    Attributes: ReplaceableAttributeList;
+    /**
+     * The update condition which, if specified, determines whether the specified attributes will be updated or not. The update condition must be satisfied in order for this request to be processed and the attributes to be updated.
+     */
+    Expected?: UpdateCondition;
+  }
+  export interface ReplaceableAttribute {
+    /**
+     * The name of the replaceable attribute.
+     */
+    Name: String;
+    /**
+     * The value of the replaceable attribute.
+     */
+    Value: String;
+    /**
+     * A flag specifying whether or not to replace the attribute/value pair or to add a new attribute/value pair. The default setting is false.
+     */
+    Replace?: Boolean;
+  }
+  export type ReplaceableAttributeList = ReplaceableAttribute[];
+  export interface ReplaceableItem {
+    /**
+     * The name of the replaceable item.
+     */
+    Name: String;
+    /**
+     * The list of attributes for a replaceable item.
+     */
+    Attributes: ReplaceableAttributeList;
+  }
+  export type ReplaceableItemList = ReplaceableItem[];
+  export interface SelectRequest {
+    /**
+     * The expression used to query the domain.
+     */
+    SelectExpression: String;
+    /**
+     * A string informing Amazon SimpleDB where to start the next list of ItemNames.
+     */
+    NextToken?: String;
+    /**
+     * Determines whether or not strong consistency should be enforced when data is read from SimpleDB. If true, any data previously written to SimpleDB will be returned. Otherwise, results will be consistent eventually, and the client may not see data that was written immediately before your read.
+     */
+    ConsistentRead?: Boolean;
+  }
+  export interface SelectResult {
+    /**
+     * A list of items that match the select expression.
+     */
+    Items?: ItemList;
+    /**
+     * An opaque token indicating that more items than MaxNumberOfItems were matched, the response size exceeded 1 megabyte, or the execution time exceeded 5 seconds.
+     */
+    NextToken?: String;
+  }
+  export type String = string;
+  export interface UpdateCondition {
+    /**
+     * The name of the attribute involved in the condition.
+     */
+    Name?: String;
+    /**
+     * The value of an attribute. This value can only be specified when the Exists parameter is equal to true.
+     */
+    Value?: String;
+    /**
+     * A value specifying whether or not the specified attribute must exist with the specified value in order for the update condition to be satisfied. Specify true if the attribute must exist for the update condition to be satisfied. Specify false if the attribute should not exist in order for the update condition to be satisfied.
+     */
+    Exists?: Boolean;
+  }
+  /**
+   * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
+   */
+  export type apiVersion = "2009-04-15"|"latest"|string;
+  export interface ClientApiVersions {
+    /**
+     * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
+     */
+    apiVersion?: apiVersion;
+  }
+  export type ClientConfiguration = ServiceConfigurationOptions & ClientApiVersions;
+  /**
+   * Contains interfaces for use with the SimpleDB client.
+   */
+  export import Types = SimpleDB;
+}
+export = SimpleDB;

--- a/generator/test/generators/aws/dummyData/validDataset/serviceClass.json
+++ b/generator/test/generators/aws/dummyData/validDataset/serviceClass.json
@@ -1,0 +1,11 @@
+{
+  "createCollection": "SimpleDB.d.ts createDomain",
+  "deleteCollection": "SimpleDB.d.ts deleteDomain",
+  "listCollections": "SimpleDB.d.ts listDomains",
+  "batchDelete": "SimpleDB.d.ts batchDeleteAttributes",
+  "batchWrite": "SimpleDB.d.ts batchPutAttributes",
+  "query": "SimpleDB.d.ts select",
+  "setAttribute": "SimpleDB.d.ts putAttributes",
+  "deleteAttribute": "SimpleDB.d.ts deleteAttributes",
+  "getAttributes": "SimpleDB.d.ts getAttributes"
+}

--- a/generator/test/generators/aws/generator.test.ts
+++ b/generator/test/generators/aws/generator.test.ts
@@ -1,29 +1,84 @@
 import { expect } from "chai";
 import { extractSDKData } from "../../../generators/aws/generator";
+import { readSourceFile, readJsonData } from "../lib/helper";
+import { SyntaxKind } from "typescript";
 
 describe("AWS generator extractSDKData", () => {
   context("with valid methods and valid AST", () => {
-    it("should class data", () => {
-      const result = extractSDKData("", "");
-    });
-  });
+    it("should return extracted class data", async () => {
+      const sdkFile: any = await readSourceFile("validDataset", "aws");
+      const data: any = await readJsonData(
+        "validDataset",
+        "aws",
+        "serviceClass"
+      );
+      let cloned = null;
+      sdkFile.forEachChild(child => {
+        if (SyntaxKind[child.kind] === "ClassDeclaration") {
+          cloned = Object.assign({}, child);
+        }
+      });
 
-  context("with invalid AST", () => {
-    it("should return Error", () => {
-      try {
-        extractSDKData("", "");
-      } catch (error) {
-        expect(error.message).to.eql("");
+      if (cloned) {
+        const result = extractSDKData(cloned, data);
+        expect(result).to.be.an("object");
+        expect(result.functions).to.be.an("array");
+        expect(result.className).to.be.string;
+      } else {
+        console.error("Error in cloning class");
       }
     });
   });
 
-  context("with invalid method data", () => {
-    it("should return Error", () => {
-      try {
-        extractSDKData("", "");
-      } catch (error) {
-        expect(error.message).to.eql("");
+  context("with invalid method data:missing method name", () => {
+    it("should drop invalid method", async () => {
+      const sdkFile: any = await readSourceFile("invalidDataset_1", "aws");
+      const data: any = await readJsonData(
+        "invalidDataset_1",
+        "aws",
+        "serviceClass"
+      );
+      let cloned = null;
+      sdkFile.forEachChild(child => {
+        if (SyntaxKind[child.kind] === "ClassDeclaration") {
+          cloned = Object.assign({}, child);
+        }
+      });
+
+      if (cloned) {
+        expect(
+          extractSDKData(cloned, data).functions.length <
+            Object.keys(data).length
+        ).to.be.true;
+      } else {
+        console.error("Error in cloning class");
+      }
+    });
+  });
+
+  context("AST with no functions", () => {
+    it("should return empty array of methods", async () => {
+      const sdkFile: any = await readSourceFile("invalidDataset_2", "aws");
+      const data: any = await readJsonData(
+        "invalidDataset_2",
+        "aws",
+        "serviceClass"
+      );
+      let cloned = null;
+      sdkFile.forEachChild(child => {
+        if (SyntaxKind[child.kind] === "ClassDeclaration") {
+          cloned = Object.assign({}, child);
+        }
+      });
+
+      if (cloned) {
+        const result = extractSDKData(cloned, data);
+        expect(result).to.be.an("object");
+        expect(result.functions).to.be.an("array");
+        expect(result.className).to.be.string;
+        expect(result.functions.length).to.eql(0);
+      } else {
+        console.error("Error in cloning class");
       }
     });
   });

--- a/generator/test/generators/aws/generator.test.ts
+++ b/generator/test/generators/aws/generator.test.ts
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+import { extractSDKData } from "../../../generators/aws/generator";
+
+describe("AWS generator extractSDKData", () => {
+  context("with valid methods and valid AST", () => {
+    it("should class data", () => {
+      const result = extractSDKData("", "");
+    });
+  });
+
+  context("with invalid AST", () => {
+    it("should return Error", () => {
+      try {
+        extractSDKData("", "");
+      } catch (error) {
+        expect(error.message).to.eql("");
+      }
+    });
+  });
+
+  context("with invalid method data", () => {
+    it("should return Error", () => {
+      try {
+        extractSDKData("", "");
+      } catch (error) {
+        expect(error.message).to.eql("");
+      }
+    });
+  });
+});

--- a/generator/test/generators/azure/dummyData/invalidDataset_1/files.json
+++ b/generator/test/generators/azure/dummyData/invalidDataset_1/files.json
@@ -1,0 +1,15 @@
+[
+  {
+    "fileName": "managedClusters.d.ts",
+    "pkgName": "arm-containerservice",
+    "ast": null,
+    "client": null,
+    "sdkFunctionNames": [
+      "createOrUpdate",
+      "deleteMethod",
+      "updateTags",
+      "listByResourceGroup",
+      "list"
+    ]
+  }
+]

--- a/generator/test/generators/azure/dummyData/invalidDataset_1/methods.json
+++ b/generator/test/generators/azure/dummyData/invalidDataset_1/methods.json
@@ -1,0 +1,47 @@
+[
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "create",
+    "SDKFunctionName": "createOrUpdate",
+    "params": [],
+    "returnType": null,
+    "client": null
+  },
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "delete",
+    "SDKFunctionName": "deleteMethod",
+    "params": [],
+    "returnType": null,
+    "client": null
+  },
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "updateTags",
+    "SDKFunctionName": "updateTags",
+    "params": [],
+    "returnType": null,
+    "client": null
+  },
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "listByResourceGroup",
+    "SDKFunctionName": "listByResourceGroup",
+    "params": [],
+    "returnType": null,
+    "client": null
+  },
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "listClusters",
+    "SDKFunctionName": "list",
+    "params": [],
+    "returnType": null,
+    "client": null
+  }
+]

--- a/generator/test/generators/azure/dummyData/invalidDataset_1/sdkFile.txt
+++ b/generator/test/generators/azure/dummyData/invalidDataset_1/sdkFile.txt
@@ -1,0 +1,9 @@
+import * as msRest from "@azure/ms-rest-js";
+import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as Models from "../models";
+import { ContainerServiceClientContext } from "../containerServiceClientContext";
+/** Class representing a ManagedClusters. */
+export declare class ManagedClusters {
+    
+}
+//# sourceMappingURL=managedClusters.d.ts.map

--- a/generator/test/generators/azure/dummyData/validDataset/files.json
+++ b/generator/test/generators/azure/dummyData/validDataset/files.json
@@ -1,0 +1,15 @@
+[
+  {
+    "fileName": "managedClusters.d.ts",
+    "pkgName": "arm-containerservice",
+    "ast": null,
+    "client": null,
+    "sdkFunctionNames": [
+      "createOrUpdate",
+      "deleteMethod",
+      "updateTags",
+      "listByResourceGroup",
+      "list"
+    ]
+  }
+]

--- a/generator/test/generators/azure/dummyData/validDataset/methods.json
+++ b/generator/test/generators/azure/dummyData/validDataset/methods.json
@@ -1,0 +1,47 @@
+[
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "create",
+    "SDKFunctionName": "createOrUpdate",
+    "params": [],
+    "returnType": null,
+    "client": null
+  },
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "delete",
+    "SDKFunctionName": "deleteMethod",
+    "params": [],
+    "returnType": null,
+    "client": null
+  },
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "updateTags",
+    "SDKFunctionName": "updateTags",
+    "params": [],
+    "returnType": null,
+    "client": null
+  },
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "listByResourceGroup",
+    "SDKFunctionName": "listByResourceGroup",
+    "params": [],
+    "returnType": null,
+    "client": null
+  },
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "listClusters",
+    "SDKFunctionName": "list",
+    "params": [],
+    "returnType": null,
+    "client": null
+  }
+]

--- a/generator/test/generators/azure/dummyData/validDataset/sdkFile.txt
+++ b/generator/test/generators/azure/dummyData/validDataset/sdkFile.txt
@@ -1,0 +1,349 @@
+import * as msRest from "@azure/ms-rest-js";
+import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as Models from "../models";
+import { ContainerServiceClientContext } from "../containerServiceClientContext";
+/** Class representing a ManagedClusters. */
+export declare class ManagedClusters {
+    private readonly client;
+    /**
+     * Create a ManagedClusters.
+     * @param {ContainerServiceClientContext} client Reference to the service client.
+     */
+    constructor(client: ContainerServiceClientContext);
+    /**
+     * Gets a list of managed clusters in the specified subscription. The operation returns properties
+     * of each managed cluster.
+     * @summary Gets a list of managed clusters in the specified subscription.
+     * @param [options] The optional parameters
+     * @returns Promise<Models.ManagedClustersListResponse>
+     */
+    list(options?: msRest.RequestOptionsBase): Promise<Models.ManagedClustersListResponse>;
+    /**
+     * @param callback The callback
+     */
+    list(callback: msRest.ServiceCallback<Models.ManagedClusterListResult>): void;
+    /**
+     * @param options The optional parameters
+     * @param callback The callback
+     */
+    list(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagedClusterListResult>): void;
+    /**
+     * Lists managed clusters in the specified subscription and resource group. The operation returns
+     * properties of each managed cluster.
+     * @summary Lists managed clusters in the specified subscription and resource group.
+     * @param resourceGroupName The name of the resource group.
+     * @param [options] The optional parameters
+     * @returns Promise<Models.ManagedClustersListByResourceGroupResponse>
+     */
+    listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagedClustersListByResourceGroupResponse>;
+    /**
+     * @param resourceGroupName The name of the resource group.
+     * @param callback The callback
+     */
+    listByResourceGroup(resourceGroupName: string, callback: msRest.ServiceCallback<Models.ManagedClusterListResult>): void;
+    /**
+     * @param resourceGroupName The name of the resource group.
+     * @param options The optional parameters
+     * @param callback The callback
+     */
+    listByResourceGroup(resourceGroupName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagedClusterListResult>): void;
+    /**
+     * Gets the details of the upgrade profile for a managed cluster with a specified resource group
+     * and name.
+     * @summary Gets upgrade profile for a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param [options] The optional parameters
+     * @returns Promise<Models.ManagedClustersGetUpgradeProfileResponse>
+     */
+    getUpgradeProfile(resourceGroupName: string, resourceName: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagedClustersGetUpgradeProfileResponse>;
+    /**
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param callback The callback
+     */
+    getUpgradeProfile(resourceGroupName: string, resourceName: string, callback: msRest.ServiceCallback<Models.ManagedClusterUpgradeProfile>): void;
+    /**
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param options The optional parameters
+     * @param callback The callback
+     */
+    getUpgradeProfile(resourceGroupName: string, resourceName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagedClusterUpgradeProfile>): void;
+    /**
+     * Gets the accessProfile for the specified role name of the managed cluster with a specified
+     * resource group and name.
+     * @summary Gets an access profile of a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param roleName The name of the role for managed cluster accessProfile resource.
+     * @param [options] The optional parameters
+     * @returns Promise<Models.ManagedClustersGetAccessProfileResponse>
+     */
+    getAccessProfile(resourceGroupName: string, resourceName: string, roleName: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagedClustersGetAccessProfileResponse>;
+    /**
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param roleName The name of the role for managed cluster accessProfile resource.
+     * @param callback The callback
+     */
+    getAccessProfile(resourceGroupName: string, resourceName: string, roleName: string, callback: msRest.ServiceCallback<Models.ManagedClusterAccessProfile>): void;
+    /**
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param roleName The name of the role for managed cluster accessProfile resource.
+     * @param options The optional parameters
+     * @param callback The callback
+     */
+    getAccessProfile(resourceGroupName: string, resourceName: string, roleName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagedClusterAccessProfile>): void;
+    /**
+     * Gets cluster admin credential of the managed cluster with a specified resource group and name.
+     * @summary Gets cluster admin credential of a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param [options] The optional parameters
+     * @returns Promise<Models.ManagedClustersListClusterAdminCredentialsResponse>
+     */
+    listClusterAdminCredentials(resourceGroupName: string, resourceName: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagedClustersListClusterAdminCredentialsResponse>;
+    /**
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param callback The callback
+     */
+    listClusterAdminCredentials(resourceGroupName: string, resourceName: string, callback: msRest.ServiceCallback<Models.CredentialResults>): void;
+    /**
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param options The optional parameters
+     * @param callback The callback
+     */
+    listClusterAdminCredentials(resourceGroupName: string, resourceName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.CredentialResults>): void;
+    /**
+     * Gets cluster user credential of the managed cluster with a specified resource group and name.
+     * @summary Gets cluster user credential of a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param [options] The optional parameters
+     * @returns Promise<Models.ManagedClustersListClusterUserCredentialsResponse>
+     */
+    listClusterUserCredentials(resourceGroupName: string, resourceName: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagedClustersListClusterUserCredentialsResponse>;
+    /**
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param callback The callback
+     */
+    listClusterUserCredentials(resourceGroupName: string, resourceName: string, callback: msRest.ServiceCallback<Models.CredentialResults>): void;
+    /**
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param options The optional parameters
+     * @param callback The callback
+     */
+    listClusterUserCredentials(resourceGroupName: string, resourceName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.CredentialResults>): void;
+    /**
+     * Gets cluster monitoring user credential of the managed cluster with a specified resource group
+     * and name.
+     * @summary Gets cluster monitoring user credential of a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param [options] The optional parameters
+     * @returns Promise<Models.ManagedClustersListClusterMonitoringUserCredentialsResponse>
+     */
+    listClusterMonitoringUserCredentials(resourceGroupName: string, resourceName: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagedClustersListClusterMonitoringUserCredentialsResponse>;
+    /**
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param callback The callback
+     */
+    listClusterMonitoringUserCredentials(resourceGroupName: string, resourceName: string, callback: msRest.ServiceCallback<Models.CredentialResults>): void;
+    /**
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param options The optional parameters
+     * @param callback The callback
+     */
+    listClusterMonitoringUserCredentials(resourceGroupName: string, resourceName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.CredentialResults>): void;
+    /**
+     * Gets the details of the managed cluster with a specified resource group and name.
+     * @summary Gets a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param [options] The optional parameters
+     * @returns Promise<Models.ManagedClustersGetResponse>
+     */
+    get(resourceGroupName: string, resourceName: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagedClustersGetResponse>;
+    /**
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param callback The callback
+     */
+    get(resourceGroupName: string, resourceName: string, callback: msRest.ServiceCallback<Models.ManagedCluster>): void;
+    /**
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param options The optional parameters
+     * @param callback The callback
+     */
+    get(resourceGroupName: string, resourceName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagedCluster>): void;
+    /**
+     * Creates or updates a managed cluster with the specified configuration for agents and Kubernetes
+     * version.
+     * @summary Creates or updates a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param parameters Parameters supplied to the Create or Update a Managed Cluster operation.
+     * @param [options] The optional parameters
+     * @returns Promise<Models.ManagedClustersCreateOrUpdateResponse>
+     */
+    createOrUpdate(resourceGroupName: string, resourceName: string, parameters: Models.ManagedCluster, options?: msRest.RequestOptionsBase): Promise<Models.ManagedClustersCreateOrUpdateResponse>;
+    /**
+     * Updates a managed cluster with the specified tags.
+     * @summary Updates tags on a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param parameters Parameters supplied to the Update Managed Cluster Tags operation.
+     * @param [options] The optional parameters
+     * @returns Promise<Models.ManagedClustersUpdateTagsResponse>
+     */
+    updateTags(resourceGroupName: string, resourceName: string, parameters: Models.TagsObject, options?: msRest.RequestOptionsBase): Promise<Models.ManagedClustersUpdateTagsResponse>;
+    /**
+     * Deletes the managed cluster with a specified resource group and name.
+     * @summary Deletes a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param [options] The optional parameters
+     * @returns Promise<msRest.RestResponse>
+     */
+    deleteMethod(resourceGroupName: string, resourceName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+    /**
+     * Update the service principal Profile for a managed cluster.
+     * @summary Reset Service Principal Profile of a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param parameters Parameters supplied to the Reset Service Principal Profile operation for a
+     * Managed Cluster.
+     * @param [options] The optional parameters
+     * @returns Promise<msRest.RestResponse>
+     */
+    resetServicePrincipalProfile(resourceGroupName: string, resourceName: string, parameters: Models.ManagedClusterServicePrincipalProfile, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+    /**
+     * Update the AAD Profile for a managed cluster.
+     * @summary Reset AAD Profile of a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param parameters Parameters supplied to the Reset AAD Profile operation for a Managed Cluster.
+     * @param [options] The optional parameters
+     * @returns Promise<msRest.RestResponse>
+     */
+    resetAADProfile(resourceGroupName: string, resourceName: string, parameters: Models.ManagedClusterAADProfile, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+    /**
+     * Rotate certificates of a managed cluster.
+     * @summary Rotate certificates of a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param [options] The optional parameters
+     * @returns Promise<msRest.RestResponse>
+     */
+    rotateClusterCertificates(resourceGroupName: string, resourceName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+    /**
+     * Creates or updates a managed cluster with the specified configuration for agents and Kubernetes
+     * version.
+     * @summary Creates or updates a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param parameters Parameters supplied to the Create or Update a Managed Cluster operation.
+     * @param [options] The optional parameters
+     * @returns Promise<msRestAzure.LROPoller>
+     */
+    beginCreateOrUpdate(resourceGroupName: string, resourceName: string, parameters: Models.ManagedCluster, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller>;
+    /**
+     * Updates a managed cluster with the specified tags.
+     * @summary Updates tags on a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param parameters Parameters supplied to the Update Managed Cluster Tags operation.
+     * @param [options] The optional parameters
+     * @returns Promise<msRestAzure.LROPoller>
+     */
+    beginUpdateTags(resourceGroupName: string, resourceName: string, parameters: Models.TagsObject, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller>;
+    /**
+     * Deletes the managed cluster with a specified resource group and name.
+     * @summary Deletes a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param [options] The optional parameters
+     * @returns Promise<msRestAzure.LROPoller>
+     */
+    beginDeleteMethod(resourceGroupName: string, resourceName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller>;
+    /**
+     * Update the service principal Profile for a managed cluster.
+     * @summary Reset Service Principal Profile of a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param parameters Parameters supplied to the Reset Service Principal Profile operation for a
+     * Managed Cluster.
+     * @param [options] The optional parameters
+     * @returns Promise<msRestAzure.LROPoller>
+     */
+    beginResetServicePrincipalProfile(resourceGroupName: string, resourceName: string, parameters: Models.ManagedClusterServicePrincipalProfile, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller>;
+    /**
+     * Update the AAD Profile for a managed cluster.
+     * @summary Reset AAD Profile of a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param parameters Parameters supplied to the Reset AAD Profile operation for a Managed Cluster.
+     * @param [options] The optional parameters
+     * @returns Promise<msRestAzure.LROPoller>
+     */
+    beginResetAADProfile(resourceGroupName: string, resourceName: string, parameters: Models.ManagedClusterAADProfile, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller>;
+    /**
+     * Rotate certificates of a managed cluster.
+     * @summary Rotate certificates of a managed cluster.
+     * @param resourceGroupName The name of the resource group.
+     * @param resourceName The name of the managed cluster resource.
+     * @param [options] The optional parameters
+     * @returns Promise<msRestAzure.LROPoller>
+     */
+    beginRotateClusterCertificates(resourceGroupName: string, resourceName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller>;
+    /**
+     * Gets a list of managed clusters in the specified subscription. The operation returns properties
+     * of each managed cluster.
+     * @summary Gets a list of managed clusters in the specified subscription.
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param [options] The optional parameters
+     * @returns Promise<Models.ManagedClustersListNextResponse>
+     */
+    listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagedClustersListNextResponse>;
+    /**
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param callback The callback
+     */
+    listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ManagedClusterListResult>): void;
+    /**
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param options The optional parameters
+     * @param callback The callback
+     */
+    listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagedClusterListResult>): void;
+    /**
+     * Lists managed clusters in the specified subscription and resource group. The operation returns
+     * properties of each managed cluster.
+     * @summary Lists managed clusters in the specified subscription and resource group.
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param [options] The optional parameters
+     * @returns Promise<Models.ManagedClustersListByResourceGroupNextResponse>
+     */
+    listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagedClustersListByResourceGroupNextResponse>;
+    /**
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param callback The callback
+     */
+    listByResourceGroupNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ManagedClusterListResult>): void;
+    /**
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param options The optional parameters
+     * @param callback The callback
+     */
+    listByResourceGroupNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagedClusterListResult>): void;
+}
+//# sourceMappingURL=managedClusters.d.ts.map

--- a/generator/test/generators/azure/generator.test.ts
+++ b/generator/test/generators/azure/generator.test.ts
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+import { extractSDKData } from "../../../generators/azure/generator";
+
+describe("Azure generator extractSDKData", () => {
+  context("with valid methods and valid AST", () => {
+    it("should class data", () => {
+      const result = extractSDKData("", "");
+    });
+  });
+
+  context("with invalid AST", () => {
+    it("should return Error", async () => {
+      try {
+        extractSDKData("", "");
+      } catch (error) {
+        expect(error.message).to.eql("");
+      }
+    });
+  });
+
+  context("with invalid method data", () => {
+    it("should return Error", async () => {
+      try {
+        extractSDKData("", "");
+      } catch (error) {
+        expect(error.message).to.eql("");
+      }
+    });
+  });
+});

--- a/generator/test/generators/azure/generator.test.ts
+++ b/generator/test/generators/azure/generator.test.ts
@@ -1,30 +1,71 @@
 import { expect } from "chai";
 import { extractSDKData } from "../../../generators/azure/generator";
+import { SyntaxKind } from "typescript";
+import { readSourceFile, readJsonData } from "../lib/helper";
 
 describe("Azure generator extractSDKData", () => {
   context("with valid methods and valid AST", () => {
-    it("should class data", () => {
-      const result = extractSDKData("", "");
+    it("should return class data", async () => {
+      const methods: any = await readJsonData(
+        "validDataset",
+        "azure",
+        "methods"
+      );
+
+      const sdkFiles: any = await readJsonData(
+        "validDataset",
+        "azure",
+        "files"
+      );
+
+      await Promise.all(
+        sdkFiles.map(async file => {
+          const sdkFile: any = await readSourceFile("validDataset", "azure");
+          sdkFile.forEachChild(child => {
+            if (SyntaxKind[child.kind] === "ClassDeclaration") {
+              file.ast = Object.assign({}, child);
+            }
+          });
+        })
+      );
+
+      const result = extractSDKData(sdkFiles, methods);
+      expect(result).to.be.an("object");
+      expect(result.functions).to.be.an("array");
     });
   });
 
-  context("with invalid AST", () => {
-    it("should return Error", async () => {
-      try {
-        extractSDKData("", "");
-      } catch (error) {
-        expect(error.message).to.eql("");
-      }
-    });
-  });
+  context("AST with no functions", () => {
+    it("should throw error", async () => {
+      const methods: any = await readJsonData(
+        "invalidDataset_1",
+        "azure",
+        "methods"
+      );
 
-  context("with invalid method data", () => {
-    it("should return Error", async () => {
-      try {
-        extractSDKData("", "");
-      } catch (error) {
-        expect(error.message).to.eql("");
-      }
+      const sdkFiles: any = await readJsonData(
+        "invalidDataset_1",
+        "azure",
+        "files"
+      );
+
+      await Promise.all(
+        sdkFiles.map(async file => {
+          const sdkFile: any = await readSourceFile(
+            "invalidDataset_1",
+            "azure"
+          );
+          sdkFile.forEachChild(child => {
+            if (SyntaxKind[child.kind] === "ClassDeclaration") {
+              file.ast = Object.assign({}, child);
+            }
+          });
+        })
+      );
+
+      expect(function() {
+        extractSDKData(sdkFiles, methods);
+      }).to.throw("Data extraction unsuccessful");
     });
   });
 });

--- a/generator/test/generators/googleCloud/dummyData/invalidDataset_1/files.json
+++ b/generator/test/generators/googleCloud/dummyData/invalidDataset_1/files.json
@@ -1,0 +1,15 @@
+[
+  {
+    "fileName": "managedClusters.d.ts",
+    "pkgName": "arm-containerservice",
+    "ast": null,
+    "client": null,
+    "sdkFunctionNames": [
+      "createOrUpdate",
+      "deleteMethod",
+      "updateTags",
+      "listByResourceGroup",
+      "list"
+    ]
+  }
+]

--- a/generator/test/generators/googleCloud/dummyData/invalidDataset_1/methods.json
+++ b/generator/test/generators/googleCloud/dummyData/invalidDataset_1/methods.json
@@ -1,0 +1,47 @@
+[
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "create",
+    "SDKFunctionName": "createOrUpdate",
+    "params": [],
+    "returnType": null,
+    "client": null
+  },
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "delete",
+    "SDKFunctionName": "deleteMethod",
+    "params": [],
+    "returnType": null,
+    "client": null
+  },
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "updateTags",
+    "SDKFunctionName": "updateTags",
+    "params": [],
+    "returnType": null,
+    "client": null
+  },
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "listByResourceGroup",
+    "SDKFunctionName": "listByResourceGroup",
+    "params": [],
+    "returnType": null,
+    "client": null
+  },
+  {
+    "pkgName": "arm-containerservice",
+    "fileName": "managedClusters.d.ts",
+    "functionName": "listClusters",
+    "SDKFunctionName": "list",
+    "params": [],
+    "returnType": null,
+    "client": null
+  }
+]

--- a/generator/test/generators/googleCloud/dummyData/invalidDataset_1/sdkFile.txt
+++ b/generator/test/generators/googleCloud/dummyData/invalidDataset_1/sdkFile.txt
@@ -1,0 +1,9 @@
+import * as msRest from "@azure/ms-rest-js";
+import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as Models from "../models";
+import { ContainerServiceClientContext } from "../containerServiceClientContext";
+/** Class representing a ManagedClusters. */
+export declare class ManagedClusters {
+    
+}
+//# sourceMappingURL=managedClusters.d.ts.map

--- a/generator/test/generators/googleCloud/dummyData/invalidDataset_2/files.json
+++ b/generator/test/generators/googleCloud/dummyData/invalidDataset_2/files.json
@@ -1,0 +1,10 @@
+[
+  {
+    "fileName": "cluster_manager_client.d.ts",
+    "version": "v1",
+    "pkgName": "container",
+    "ast": null,
+    "client": null,
+    "sdkFunctionNames": ["createCluster", "deleteCluster", "listClusters"]
+  }
+]

--- a/generator/test/generators/googleCloud/dummyData/invalidDataset_2/methods.json
+++ b/generator/test/generators/googleCloud/dummyData/invalidDataset_2/methods.json
@@ -1,0 +1,35 @@
+[
+  {
+    "pkgName": "container",
+    "version": "v1",
+    "fileName": "cluster_manager_client.d.ts",
+    "functionName": "create",
+    "SDKFunctionName": "createCluster",
+    "params": [],
+    "returnType": null,
+    "returnTypeName": null,
+    "client": null
+  },
+  {
+    "pkgName": "container",
+    "version": "v1",
+    "fileName": "cluster_manager_client.d.ts",
+    "functionName": "delete",
+    "SDKFunctionName": "deleteCluster",
+    "params": [],
+    "returnType": null,
+    "returnTypeName": null,
+    "client": null
+  },
+  {
+    "pkgName": "container",
+    "version": "v1",
+    "fileName": "cluster_manager_client.d.ts",
+    "functionName": "listClusters",
+    "SDKFunctionName": "listClusters",
+    "params": [],
+    "returnType": null,
+    "returnTypeName": null,
+    "client": null
+  }
+]

--- a/generator/test/generators/googleCloud/dummyData/invalidDataset_2/sdkFile.txt
+++ b/generator/test/generators/googleCloud/dummyData/invalidDataset_2/sdkFile.txt
@@ -1,0 +1,13 @@
+/// <reference types="node" />
+import * as gax from 'google-gax';
+import { Callback, Descriptors, ClientOptions, PaginationCallback } from 'google-gax';
+import { Transform } from 'stream';
+import * as protos from '../../protos/protos';
+/**
+ *  Google Kubernetes Engine Cluster Manager v1
+ * @class
+ * @memberof v1
+ */
+export declare class ClusterManagerClient {
+    
+}

--- a/generator/test/generators/googleCloud/dummyData/validDataset_1/files.json
+++ b/generator/test/generators/googleCloud/dummyData/validDataset_1/files.json
@@ -1,0 +1,26 @@
+[
+  {
+    "fileName": "change.d.ts",
+    "pkgName": "dns",
+    "classes": null,
+    "sdkFunctionNames": []
+  },
+  {
+    "fileName": "index.d.ts",
+    "pkgName": "dns",
+    "classes": null,
+    "sdkFunctionNames": ["getZones"]
+  },
+  {
+    "fileName": "record.d.ts",
+    "pkgName": "dns",
+    "classes": null,
+    "sdkFunctionNames": []
+  },
+  {
+    "fileName": "zone.d.ts",
+    "pkgName": "dns",
+    "classes": null,
+    "sdkFunctionNames": ["create"]
+  }
+]

--- a/generator/test/generators/googleCloud/dummyData/validDataset_1/methods.json
+++ b/generator/test/generators/googleCloud/dummyData/validDataset_1/methods.json
@@ -1,0 +1,24 @@
+[
+  {
+    "pkgName": "dns",
+    "version": null,
+    "fileName": "index.d.ts",
+    "functionName": "listZones",
+    "SDKFunctionName": "getZones",
+    "params": [],
+    "returnType": null,
+    "returnTypeName": null,
+    "client": null
+  },
+  {
+    "pkgName": "dns",
+    "version": null,
+    "fileName": "zone.d.ts",
+    "functionName": "createZone",
+    "SDKFunctionName": "create",
+    "params": [],
+    "returnType": null,
+    "returnTypeName": null,
+    "client": null
+  }
+]

--- a/generator/test/generators/googleCloud/dummyData/validDataset_1/sdkFile.txt
+++ b/generator/test/generators/googleCloud/dummyData/validDataset_1/sdkFile.txt
@@ -1,0 +1,251 @@
+/// <reference types="node" />
+import * as gax from 'google-gax';
+import { Callback, Descriptors, ClientOptions, PaginationCallback } from 'google-gax';
+import { Transform } from 'stream';
+import * as protos from '../../protos/protos';
+/**
+ *  Google Kubernetes Engine Cluster Manager v1
+ * @class
+ * @memberof v1
+ */
+export declare class ClusterManagerClient {
+    private _terminated;
+    private _opts;
+    private _gaxModule;
+    private _gaxGrpc;
+    private _protos;
+    private _defaults;
+    auth: gax.GoogleAuth;
+    descriptors: Descriptors;
+    innerApiCalls: {
+        [name: string]: Function;
+    };
+    clusterManagerStub?: Promise<{
+        [name: string]: Function;
+    }>;
+    /**
+     * Construct an instance of ClusterManagerClient.
+     *
+     * @param {object} [options] - The configuration object. See the subsequent
+     *   parameters for more details.
+     * @param {object} [options.credentials] - Credentials object.
+     * @param {string} [options.credentials.client_email]
+     * @param {string} [options.credentials.private_key]
+     * @param {string} [options.email] - Account email address. Required when
+     *     using a .pem or .p12 keyFilename.
+     * @param {string} [options.keyFilename] - Full path to the a .json, .pem, or
+     *     .p12 key downloaded from the Google Developers Console. If you provide
+     *     a path to a JSON file, the projectId option below is not necessary.
+     *     NOTE: .pem and .p12 require you to specify options.email as well.
+     * @param {number} [options.port] - The port on which to connect to
+     *     the remote host.
+     * @param {string} [options.projectId] - The project ID from the Google
+     *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
+     *     the environment variable GCLOUD_PROJECT for your project ID. If your
+     *     app is running in an environment which supports
+     *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
+     *     your project ID will be detected automatically.
+     * @param {string} [options.apiEndpoint] - The domain name of the
+     *     API remote host.
+     */
+    constructor(opts?: ClientOptions);
+    /**
+     * Initialize the client.
+     * Performs asynchronous operations (such as authentication) and prepares the client.
+     * This function will be called automatically when any class method is called for the
+     * first time, but if you need to initialize it before calling an actual method,
+     * feel free to call initialize() directly.
+     *
+     * You can await on this method if you want to make sure the client is initialized.
+     *
+     * @returns {Promise} A promise that resolves to an authenticated service stub.
+     */
+    initialize(): Promise<{
+        [name: string]: Function;
+    }>;
+    /**
+     * The DNS address for this API service.
+     */
+    static get servicePath(): string;
+    /**
+     * The DNS address for this API service - same as servicePath(),
+     * exists for compatibility reasons.
+     */
+    static get apiEndpoint(): string;
+    /**
+     * The port for this API service.
+     */
+    static get port(): number;
+    /**
+     * The scopes needed to make gRPC calls for every method defined
+     * in this service.
+     */
+    static get scopes(): string[];
+    getProjectId(): Promise<string>;
+    getProjectId(callback: Callback<string, undefined, undefined>): void;
+    listClusters(request: protos.google.container.v1.IListClustersRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IListClustersResponse, protos.google.container.v1.IListClustersRequest | undefined, {} | undefined]>;
+    listClusters(request: protos.google.container.v1.IListClustersRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IListClustersResponse, protos.google.container.v1.IListClustersRequest | null | undefined, {} | null | undefined>): void;
+    listClusters(request: protos.google.container.v1.IListClustersRequest, callback: Callback<protos.google.container.v1.IListClustersResponse, protos.google.container.v1.IListClustersRequest | null | undefined, {} | null | undefined>): void;
+    getCluster(request: protos.google.container.v1.IGetClusterRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.ICluster, protos.google.container.v1.IGetClusterRequest | undefined, {} | undefined]>;
+    getCluster(request: protos.google.container.v1.IGetClusterRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.ICluster, protos.google.container.v1.IGetClusterRequest | null | undefined, {} | null | undefined>): void;
+    getCluster(request: protos.google.container.v1.IGetClusterRequest, callback: Callback<protos.google.container.v1.ICluster, protos.google.container.v1.IGetClusterRequest | null | undefined, {} | null | undefined>): void;
+    createCluster(request: protos.google.container.v1.ICreateClusterRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ICreateClusterRequest | undefined, {} | undefined]>;
+    createCluster(request: protos.google.container.v1.ICreateClusterRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ICreateClusterRequest | null | undefined, {} | null | undefined>): void;
+    createCluster(request: protos.google.container.v1.ICreateClusterRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ICreateClusterRequest | null | undefined, {} | null | undefined>): void;
+    updateCluster(request: protos.google.container.v1.IUpdateClusterRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateClusterRequest | undefined, {} | undefined]>;
+    updateCluster(request: protos.google.container.v1.IUpdateClusterRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateClusterRequest | null | undefined, {} | null | undefined>): void;
+    updateCluster(request: protos.google.container.v1.IUpdateClusterRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateClusterRequest | null | undefined, {} | null | undefined>): void;
+    updateNodePool(request: protos.google.container.v1.IUpdateNodePoolRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateNodePoolRequest | undefined, {} | undefined]>;
+    updateNodePool(request: protos.google.container.v1.IUpdateNodePoolRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    updateNodePool(request: protos.google.container.v1.IUpdateNodePoolRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    setNodePoolAutoscaling(request: protos.google.container.v1.ISetNodePoolAutoscalingRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolAutoscalingRequest | undefined, {} | undefined]>;
+    setNodePoolAutoscaling(request: protos.google.container.v1.ISetNodePoolAutoscalingRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolAutoscalingRequest | null | undefined, {} | null | undefined>): void;
+    setNodePoolAutoscaling(request: protos.google.container.v1.ISetNodePoolAutoscalingRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolAutoscalingRequest | null | undefined, {} | null | undefined>): void;
+    setLoggingService(request: protos.google.container.v1.ISetLoggingServiceRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetLoggingServiceRequest | undefined, {} | undefined]>;
+    setLoggingService(request: protos.google.container.v1.ISetLoggingServiceRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLoggingServiceRequest | null | undefined, {} | null | undefined>): void;
+    setLoggingService(request: protos.google.container.v1.ISetLoggingServiceRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLoggingServiceRequest | null | undefined, {} | null | undefined>): void;
+    setMonitoringService(request: protos.google.container.v1.ISetMonitoringServiceRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetMonitoringServiceRequest | undefined, {} | undefined]>;
+    setMonitoringService(request: protos.google.container.v1.ISetMonitoringServiceRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetMonitoringServiceRequest | null | undefined, {} | null | undefined>): void;
+    setMonitoringService(request: protos.google.container.v1.ISetMonitoringServiceRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetMonitoringServiceRequest | null | undefined, {} | null | undefined>): void;
+    setAddonsConfig(request: protos.google.container.v1.ISetAddonsConfigRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetAddonsConfigRequest | undefined, {} | undefined]>;
+    setAddonsConfig(request: protos.google.container.v1.ISetAddonsConfigRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetAddonsConfigRequest | null | undefined, {} | null | undefined>): void;
+    setAddonsConfig(request: protos.google.container.v1.ISetAddonsConfigRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetAddonsConfigRequest | null | undefined, {} | null | undefined>): void;
+    setLocations(request: protos.google.container.v1.ISetLocationsRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetLocationsRequest | undefined, {} | undefined]>;
+    setLocations(request: protos.google.container.v1.ISetLocationsRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLocationsRequest | null | undefined, {} | null | undefined>): void;
+    setLocations(request: protos.google.container.v1.ISetLocationsRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLocationsRequest | null | undefined, {} | null | undefined>): void;
+    updateMaster(request: protos.google.container.v1.IUpdateMasterRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateMasterRequest | undefined, {} | undefined]>;
+    updateMaster(request: protos.google.container.v1.IUpdateMasterRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateMasterRequest | null | undefined, {} | null | undefined>): void;
+    updateMaster(request: protos.google.container.v1.IUpdateMasterRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateMasterRequest | null | undefined, {} | null | undefined>): void;
+    setMasterAuth(request: protos.google.container.v1.ISetMasterAuthRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetMasterAuthRequest | undefined, {} | undefined]>;
+    setMasterAuth(request: protos.google.container.v1.ISetMasterAuthRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetMasterAuthRequest | null | undefined, {} | null | undefined>): void;
+    setMasterAuth(request: protos.google.container.v1.ISetMasterAuthRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetMasterAuthRequest | null | undefined, {} | null | undefined>): void;
+    deleteCluster(request: protos.google.container.v1.IDeleteClusterRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IDeleteClusterRequest | undefined, {} | undefined]>;
+    deleteCluster(request: protos.google.container.v1.IDeleteClusterRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IDeleteClusterRequest | null | undefined, {} | null | undefined>): void;
+    deleteCluster(request: protos.google.container.v1.IDeleteClusterRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IDeleteClusterRequest | null | undefined, {} | null | undefined>): void;
+    listOperations(request: protos.google.container.v1.IListOperationsRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IListOperationsResponse, protos.google.container.v1.IListOperationsRequest | undefined, {} | undefined]>;
+    listOperations(request: protos.google.container.v1.IListOperationsRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IListOperationsResponse, protos.google.container.v1.IListOperationsRequest | null | undefined, {} | null | undefined>): void;
+    listOperations(request: protos.google.container.v1.IListOperationsRequest, callback: Callback<protos.google.container.v1.IListOperationsResponse, protos.google.container.v1.IListOperationsRequest | null | undefined, {} | null | undefined>): void;
+    getOperation(request: protos.google.container.v1.IGetOperationRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IGetOperationRequest | undefined, {} | undefined]>;
+    getOperation(request: protos.google.container.v1.IGetOperationRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IGetOperationRequest | null | undefined, {} | null | undefined>): void;
+    getOperation(request: protos.google.container.v1.IGetOperationRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IGetOperationRequest | null | undefined, {} | null | undefined>): void;
+    cancelOperation(request: protos.google.container.v1.ICancelOperationRequest, options?: gax.CallOptions): Promise<[protos.google.protobuf.IEmpty, protos.google.container.v1.ICancelOperationRequest | undefined, {} | undefined]>;
+    cancelOperation(request: protos.google.container.v1.ICancelOperationRequest, options: gax.CallOptions, callback: Callback<protos.google.protobuf.IEmpty, protos.google.container.v1.ICancelOperationRequest | null | undefined, {} | null | undefined>): void;
+    cancelOperation(request: protos.google.container.v1.ICancelOperationRequest, callback: Callback<protos.google.protobuf.IEmpty, protos.google.container.v1.ICancelOperationRequest | null | undefined, {} | null | undefined>): void;
+    getServerConfig(request: protos.google.container.v1.IGetServerConfigRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IServerConfig, protos.google.container.v1.IGetServerConfigRequest | undefined, {} | undefined]>;
+    getServerConfig(request: protos.google.container.v1.IGetServerConfigRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IServerConfig, protos.google.container.v1.IGetServerConfigRequest | null | undefined, {} | null | undefined>): void;
+    getServerConfig(request: protos.google.container.v1.IGetServerConfigRequest, callback: Callback<protos.google.container.v1.IServerConfig, protos.google.container.v1.IGetServerConfigRequest | null | undefined, {} | null | undefined>): void;
+    listNodePools(request: protos.google.container.v1.IListNodePoolsRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IListNodePoolsResponse, protos.google.container.v1.IListNodePoolsRequest | undefined, {} | undefined]>;
+    listNodePools(request: protos.google.container.v1.IListNodePoolsRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IListNodePoolsResponse, protos.google.container.v1.IListNodePoolsRequest | null | undefined, {} | null | undefined>): void;
+    listNodePools(request: protos.google.container.v1.IListNodePoolsRequest, callback: Callback<protos.google.container.v1.IListNodePoolsResponse, protos.google.container.v1.IListNodePoolsRequest | null | undefined, {} | null | undefined>): void;
+    getNodePool(request: protos.google.container.v1.IGetNodePoolRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.INodePool, protos.google.container.v1.IGetNodePoolRequest | undefined, {} | undefined]>;
+    getNodePool(request: protos.google.container.v1.IGetNodePoolRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.INodePool, protos.google.container.v1.IGetNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    getNodePool(request: protos.google.container.v1.IGetNodePoolRequest, callback: Callback<protos.google.container.v1.INodePool, protos.google.container.v1.IGetNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    createNodePool(request: protos.google.container.v1.ICreateNodePoolRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ICreateNodePoolRequest | undefined, {} | undefined]>;
+    createNodePool(request: protos.google.container.v1.ICreateNodePoolRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ICreateNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    createNodePool(request: protos.google.container.v1.ICreateNodePoolRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ICreateNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    deleteNodePool(request: protos.google.container.v1.IDeleteNodePoolRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IDeleteNodePoolRequest | undefined, {} | undefined]>;
+    deleteNodePool(request: protos.google.container.v1.IDeleteNodePoolRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IDeleteNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    deleteNodePool(request: protos.google.container.v1.IDeleteNodePoolRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IDeleteNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    rollbackNodePoolUpgrade(request: protos.google.container.v1.IRollbackNodePoolUpgradeRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IRollbackNodePoolUpgradeRequest | undefined, {} | undefined]>;
+    rollbackNodePoolUpgrade(request: protos.google.container.v1.IRollbackNodePoolUpgradeRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IRollbackNodePoolUpgradeRequest | null | undefined, {} | null | undefined>): void;
+    rollbackNodePoolUpgrade(request: protos.google.container.v1.IRollbackNodePoolUpgradeRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IRollbackNodePoolUpgradeRequest | null | undefined, {} | null | undefined>): void;
+    setNodePoolManagement(request: protos.google.container.v1.ISetNodePoolManagementRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolManagementRequest | undefined, {} | undefined]>;
+    setNodePoolManagement(request: protos.google.container.v1.ISetNodePoolManagementRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolManagementRequest | null | undefined, {} | null | undefined>): void;
+    setNodePoolManagement(request: protos.google.container.v1.ISetNodePoolManagementRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolManagementRequest | null | undefined, {} | null | undefined>): void;
+    setLabels(request: protos.google.container.v1.ISetLabelsRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetLabelsRequest | undefined, {} | undefined]>;
+    setLabels(request: protos.google.container.v1.ISetLabelsRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLabelsRequest | null | undefined, {} | null | undefined>): void;
+    setLabels(request: protos.google.container.v1.ISetLabelsRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLabelsRequest | null | undefined, {} | null | undefined>): void;
+    setLegacyAbac(request: protos.google.container.v1.ISetLegacyAbacRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetLegacyAbacRequest | undefined, {} | undefined]>;
+    setLegacyAbac(request: protos.google.container.v1.ISetLegacyAbacRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLegacyAbacRequest | null | undefined, {} | null | undefined>): void;
+    setLegacyAbac(request: protos.google.container.v1.ISetLegacyAbacRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLegacyAbacRequest | null | undefined, {} | null | undefined>): void;
+    startIPRotation(request: protos.google.container.v1.IStartIPRotationRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IStartIPRotationRequest | undefined, {} | undefined]>;
+    startIPRotation(request: protos.google.container.v1.IStartIPRotationRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IStartIPRotationRequest | null | undefined, {} | null | undefined>): void;
+    startIPRotation(request: protos.google.container.v1.IStartIPRotationRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IStartIPRotationRequest | null | undefined, {} | null | undefined>): void;
+    completeIPRotation(request: protos.google.container.v1.ICompleteIPRotationRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ICompleteIPRotationRequest | undefined, {} | undefined]>;
+    completeIPRotation(request: protos.google.container.v1.ICompleteIPRotationRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ICompleteIPRotationRequest | null | undefined, {} | null | undefined>): void;
+    completeIPRotation(request: protos.google.container.v1.ICompleteIPRotationRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ICompleteIPRotationRequest | null | undefined, {} | null | undefined>): void;
+    setNodePoolSize(request: protos.google.container.v1.ISetNodePoolSizeRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolSizeRequest | undefined, {} | undefined]>;
+    setNodePoolSize(request: protos.google.container.v1.ISetNodePoolSizeRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolSizeRequest | null | undefined, {} | null | undefined>): void;
+    setNodePoolSize(request: protos.google.container.v1.ISetNodePoolSizeRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolSizeRequest | null | undefined, {} | null | undefined>): void;
+    setNetworkPolicy(request: protos.google.container.v1.ISetNetworkPolicyRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetNetworkPolicyRequest | undefined, {} | undefined]>;
+    setNetworkPolicy(request: protos.google.container.v1.ISetNetworkPolicyRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNetworkPolicyRequest | null | undefined, {} | null | undefined>): void;
+    setNetworkPolicy(request: protos.google.container.v1.ISetNetworkPolicyRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNetworkPolicyRequest | null | undefined, {} | null | undefined>): void;
+    setMaintenancePolicy(request: protos.google.container.v1.ISetMaintenancePolicyRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetMaintenancePolicyRequest | undefined, {} | undefined]>;
+    setMaintenancePolicy(request: protos.google.container.v1.ISetMaintenancePolicyRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetMaintenancePolicyRequest | null | undefined, {} | null | undefined>): void;
+    setMaintenancePolicy(request: protos.google.container.v1.ISetMaintenancePolicyRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetMaintenancePolicyRequest | null | undefined, {} | null | undefined>): void;
+    listUsableSubnetworks(request: protos.google.container.v1.IListUsableSubnetworksRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IUsableSubnetwork[], protos.google.container.v1.IListUsableSubnetworksRequest | null, protos.google.container.v1.IListUsableSubnetworksResponse]>;
+    listUsableSubnetworks(request: protos.google.container.v1.IListUsableSubnetworksRequest, options: gax.CallOptions, callback: PaginationCallback<protos.google.container.v1.IListUsableSubnetworksRequest, protos.google.container.v1.IListUsableSubnetworksResponse | null | undefined, protos.google.container.v1.IUsableSubnetwork>): void;
+    listUsableSubnetworks(request: protos.google.container.v1.IListUsableSubnetworksRequest, callback: PaginationCallback<protos.google.container.v1.IListUsableSubnetworksRequest, protos.google.container.v1.IListUsableSubnetworksResponse | null | undefined, protos.google.container.v1.IUsableSubnetwork>): void;
+    /**
+     * Equivalent to {@link listUsableSubnetworks}, but returns a NodeJS Stream object.
+     *
+     * This fetches the paged responses for {@link listUsableSubnetworks} continuously
+     * and invokes the callback registered for 'data' event for each element in the
+     * responses.
+     *
+     * The returned object has 'end' method when no more elements are required.
+     *
+     * autoPaginate option will be ignored.
+     *
+     * @see {@link https://nodejs.org/api/stream.html}
+     *
+     * @param {Object} request
+     *   The request object that will be sent.
+     * @param {string} request.parent
+     *   The parent project where subnetworks are usable.
+     *   Specified in the format `projects/*`.
+     * @param {string} request.filter
+     *   Filtering currently only supports equality on the networkProjectId and must
+     *   be in the form: "networkProjectId=[PROJECTID]", where `networkProjectId`
+     *   is the project which owns the listed subnetworks. This defaults to the
+     *   parent project ID.
+     * @param {number} request.pageSize
+     *   The max number of results per page that should be returned. If the number
+     *   of available results is larger than `page_size`, a `next_page_token` is
+     *   returned which can be used to get the next page of results in subsequent
+     *   requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
+     * @param {string} request.pageToken
+     *   Specifies a page token to use. Set this to the nextPageToken returned by
+     *   previous list requests to get the next page of results.
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which emits an object representing [UsableSubnetwork]{@link google.container.v1.UsableSubnetwork} on 'data' event.
+     */
+    listUsableSubnetworksStream(request?: protos.google.container.v1.IListUsableSubnetworksRequest, options?: gax.CallOptions): Transform;
+    /**
+     * Equivalent to {@link listUsableSubnetworks}, but returns an iterable object.
+     *
+     * for-await-of syntax is used with the iterable to recursively get response element on-demand.
+     *
+     * @param {Object} request
+     *   The request object that will be sent.
+     * @param {string} request.parent
+     *   The parent project where subnetworks are usable.
+     *   Specified in the format `projects/*`.
+     * @param {string} request.filter
+     *   Filtering currently only supports equality on the networkProjectId and must
+     *   be in the form: "networkProjectId=[PROJECTID]", where `networkProjectId`
+     *   is the project which owns the listed subnetworks. This defaults to the
+     *   parent project ID.
+     * @param {number} request.pageSize
+     *   The max number of results per page that should be returned. If the number
+     *   of available results is larger than `page_size`, a `next_page_token` is
+     *   returned which can be used to get the next page of results in subsequent
+     *   requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
+     * @param {string} request.pageToken
+     *   Specifies a page token to use. Set this to the nextPageToken returned by
+     *   previous list requests to get the next page of results.
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Object}
+     *   An iterable Object that conforms to @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols.
+     */
+    listUsableSubnetworksAsync(request?: protos.google.container.v1.IListUsableSubnetworksRequest, options?: gax.CallOptions): AsyncIterable<protos.google.container.v1.IUsableSubnetwork>;
+    /**
+     * Terminate the GRPC channel and close the client.
+     *
+     * The client will no longer be usable and all future behavior is undefined.
+     */
+    close(): Promise<void>;
+}

--- a/generator/test/generators/googleCloud/dummyData/validDataset_2/files.json
+++ b/generator/test/generators/googleCloud/dummyData/validDataset_2/files.json
@@ -1,0 +1,10 @@
+[
+  {
+    "fileName": "cluster_manager_client.d.ts",
+    "version": "v1",
+    "pkgName": "container",
+    "ast": null,
+    "client": null,
+    "sdkFunctionNames": ["createCluster", "deleteCluster", "listClusters"]
+  }
+]

--- a/generator/test/generators/googleCloud/dummyData/validDataset_2/methods.json
+++ b/generator/test/generators/googleCloud/dummyData/validDataset_2/methods.json
@@ -1,0 +1,35 @@
+[
+  {
+    "pkgName": "container",
+    "version": "v1",
+    "fileName": "cluster_manager_client.d.ts",
+    "functionName": "create",
+    "SDKFunctionName": "createCluster",
+    "params": [],
+    "returnType": null,
+    "returnTypeName": null,
+    "client": null
+  },
+  {
+    "pkgName": "container",
+    "version": "v1",
+    "fileName": "cluster_manager_client.d.ts",
+    "functionName": "delete",
+    "SDKFunctionName": "deleteCluster",
+    "params": [],
+    "returnType": null,
+    "returnTypeName": null,
+    "client": null
+  },
+  {
+    "pkgName": "container",
+    "version": "v1",
+    "fileName": "cluster_manager_client.d.ts",
+    "functionName": "listClusters",
+    "SDKFunctionName": "listClusters",
+    "params": [],
+    "returnType": null,
+    "returnTypeName": null,
+    "client": null
+  }
+]

--- a/generator/test/generators/googleCloud/dummyData/validDataset_2/sdkFile.txt
+++ b/generator/test/generators/googleCloud/dummyData/validDataset_2/sdkFile.txt
@@ -1,0 +1,251 @@
+/// <reference types="node" />
+import * as gax from 'google-gax';
+import { Callback, Descriptors, ClientOptions, PaginationCallback } from 'google-gax';
+import { Transform } from 'stream';
+import * as protos from '../../protos/protos';
+/**
+ *  Google Kubernetes Engine Cluster Manager v1
+ * @class
+ * @memberof v1
+ */
+export declare class ClusterManagerClient {
+    private _terminated;
+    private _opts;
+    private _gaxModule;
+    private _gaxGrpc;
+    private _protos;
+    private _defaults;
+    auth: gax.GoogleAuth;
+    descriptors: Descriptors;
+    innerApiCalls: {
+        [name: string]: Function;
+    };
+    clusterManagerStub?: Promise<{
+        [name: string]: Function;
+    }>;
+    /**
+     * Construct an instance of ClusterManagerClient.
+     *
+     * @param {object} [options] - The configuration object. See the subsequent
+     *   parameters for more details.
+     * @param {object} [options.credentials] - Credentials object.
+     * @param {string} [options.credentials.client_email]
+     * @param {string} [options.credentials.private_key]
+     * @param {string} [options.email] - Account email address. Required when
+     *     using a .pem or .p12 keyFilename.
+     * @param {string} [options.keyFilename] - Full path to the a .json, .pem, or
+     *     .p12 key downloaded from the Google Developers Console. If you provide
+     *     a path to a JSON file, the projectId option below is not necessary.
+     *     NOTE: .pem and .p12 require you to specify options.email as well.
+     * @param {number} [options.port] - The port on which to connect to
+     *     the remote host.
+     * @param {string} [options.projectId] - The project ID from the Google
+     *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
+     *     the environment variable GCLOUD_PROJECT for your project ID. If your
+     *     app is running in an environment which supports
+     *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
+     *     your project ID will be detected automatically.
+     * @param {string} [options.apiEndpoint] - The domain name of the
+     *     API remote host.
+     */
+    constructor(opts?: ClientOptions);
+    /**
+     * Initialize the client.
+     * Performs asynchronous operations (such as authentication) and prepares the client.
+     * This function will be called automatically when any class method is called for the
+     * first time, but if you need to initialize it before calling an actual method,
+     * feel free to call initialize() directly.
+     *
+     * You can await on this method if you want to make sure the client is initialized.
+     *
+     * @returns {Promise} A promise that resolves to an authenticated service stub.
+     */
+    initialize(): Promise<{
+        [name: string]: Function;
+    }>;
+    /**
+     * The DNS address for this API service.
+     */
+    static get servicePath(): string;
+    /**
+     * The DNS address for this API service - same as servicePath(),
+     * exists for compatibility reasons.
+     */
+    static get apiEndpoint(): string;
+    /**
+     * The port for this API service.
+     */
+    static get port(): number;
+    /**
+     * The scopes needed to make gRPC calls for every method defined
+     * in this service.
+     */
+    static get scopes(): string[];
+    getProjectId(): Promise<string>;
+    getProjectId(callback: Callback<string, undefined, undefined>): void;
+    listClusters(request: protos.google.container.v1.IListClustersRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IListClustersResponse, protos.google.container.v1.IListClustersRequest | undefined, {} | undefined]>;
+    listClusters(request: protos.google.container.v1.IListClustersRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IListClustersResponse, protos.google.container.v1.IListClustersRequest | null | undefined, {} | null | undefined>): void;
+    listClusters(request: protos.google.container.v1.IListClustersRequest, callback: Callback<protos.google.container.v1.IListClustersResponse, protos.google.container.v1.IListClustersRequest | null | undefined, {} | null | undefined>): void;
+    getCluster(request: protos.google.container.v1.IGetClusterRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.ICluster, protos.google.container.v1.IGetClusterRequest | undefined, {} | undefined]>;
+    getCluster(request: protos.google.container.v1.IGetClusterRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.ICluster, protos.google.container.v1.IGetClusterRequest | null | undefined, {} | null | undefined>): void;
+    getCluster(request: protos.google.container.v1.IGetClusterRequest, callback: Callback<protos.google.container.v1.ICluster, protos.google.container.v1.IGetClusterRequest | null | undefined, {} | null | undefined>): void;
+    createCluster(request: protos.google.container.v1.ICreateClusterRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ICreateClusterRequest | undefined, {} | undefined]>;
+    createCluster(request: protos.google.container.v1.ICreateClusterRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ICreateClusterRequest | null | undefined, {} | null | undefined>): void;
+    createCluster(request: protos.google.container.v1.ICreateClusterRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ICreateClusterRequest | null | undefined, {} | null | undefined>): void;
+    updateCluster(request: protos.google.container.v1.IUpdateClusterRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateClusterRequest | undefined, {} | undefined]>;
+    updateCluster(request: protos.google.container.v1.IUpdateClusterRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateClusterRequest | null | undefined, {} | null | undefined>): void;
+    updateCluster(request: protos.google.container.v1.IUpdateClusterRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateClusterRequest | null | undefined, {} | null | undefined>): void;
+    updateNodePool(request: protos.google.container.v1.IUpdateNodePoolRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateNodePoolRequest | undefined, {} | undefined]>;
+    updateNodePool(request: protos.google.container.v1.IUpdateNodePoolRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    updateNodePool(request: protos.google.container.v1.IUpdateNodePoolRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    setNodePoolAutoscaling(request: protos.google.container.v1.ISetNodePoolAutoscalingRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolAutoscalingRequest | undefined, {} | undefined]>;
+    setNodePoolAutoscaling(request: protos.google.container.v1.ISetNodePoolAutoscalingRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolAutoscalingRequest | null | undefined, {} | null | undefined>): void;
+    setNodePoolAutoscaling(request: protos.google.container.v1.ISetNodePoolAutoscalingRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolAutoscalingRequest | null | undefined, {} | null | undefined>): void;
+    setLoggingService(request: protos.google.container.v1.ISetLoggingServiceRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetLoggingServiceRequest | undefined, {} | undefined]>;
+    setLoggingService(request: protos.google.container.v1.ISetLoggingServiceRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLoggingServiceRequest | null | undefined, {} | null | undefined>): void;
+    setLoggingService(request: protos.google.container.v1.ISetLoggingServiceRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLoggingServiceRequest | null | undefined, {} | null | undefined>): void;
+    setMonitoringService(request: protos.google.container.v1.ISetMonitoringServiceRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetMonitoringServiceRequest | undefined, {} | undefined]>;
+    setMonitoringService(request: protos.google.container.v1.ISetMonitoringServiceRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetMonitoringServiceRequest | null | undefined, {} | null | undefined>): void;
+    setMonitoringService(request: protos.google.container.v1.ISetMonitoringServiceRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetMonitoringServiceRequest | null | undefined, {} | null | undefined>): void;
+    setAddonsConfig(request: protos.google.container.v1.ISetAddonsConfigRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetAddonsConfigRequest | undefined, {} | undefined]>;
+    setAddonsConfig(request: protos.google.container.v1.ISetAddonsConfigRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetAddonsConfigRequest | null | undefined, {} | null | undefined>): void;
+    setAddonsConfig(request: protos.google.container.v1.ISetAddonsConfigRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetAddonsConfigRequest | null | undefined, {} | null | undefined>): void;
+    setLocations(request: protos.google.container.v1.ISetLocationsRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetLocationsRequest | undefined, {} | undefined]>;
+    setLocations(request: protos.google.container.v1.ISetLocationsRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLocationsRequest | null | undefined, {} | null | undefined>): void;
+    setLocations(request: protos.google.container.v1.ISetLocationsRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLocationsRequest | null | undefined, {} | null | undefined>): void;
+    updateMaster(request: protos.google.container.v1.IUpdateMasterRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateMasterRequest | undefined, {} | undefined]>;
+    updateMaster(request: protos.google.container.v1.IUpdateMasterRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateMasterRequest | null | undefined, {} | null | undefined>): void;
+    updateMaster(request: protos.google.container.v1.IUpdateMasterRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IUpdateMasterRequest | null | undefined, {} | null | undefined>): void;
+    setMasterAuth(request: protos.google.container.v1.ISetMasterAuthRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetMasterAuthRequest | undefined, {} | undefined]>;
+    setMasterAuth(request: protos.google.container.v1.ISetMasterAuthRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetMasterAuthRequest | null | undefined, {} | null | undefined>): void;
+    setMasterAuth(request: protos.google.container.v1.ISetMasterAuthRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetMasterAuthRequest | null | undefined, {} | null | undefined>): void;
+    deleteCluster(request: protos.google.container.v1.IDeleteClusterRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IDeleteClusterRequest | undefined, {} | undefined]>;
+    deleteCluster(request: protos.google.container.v1.IDeleteClusterRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IDeleteClusterRequest | null | undefined, {} | null | undefined>): void;
+    deleteCluster(request: protos.google.container.v1.IDeleteClusterRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IDeleteClusterRequest | null | undefined, {} | null | undefined>): void;
+    listOperations(request: protos.google.container.v1.IListOperationsRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IListOperationsResponse, protos.google.container.v1.IListOperationsRequest | undefined, {} | undefined]>;
+    listOperations(request: protos.google.container.v1.IListOperationsRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IListOperationsResponse, protos.google.container.v1.IListOperationsRequest | null | undefined, {} | null | undefined>): void;
+    listOperations(request: protos.google.container.v1.IListOperationsRequest, callback: Callback<protos.google.container.v1.IListOperationsResponse, protos.google.container.v1.IListOperationsRequest | null | undefined, {} | null | undefined>): void;
+    getOperation(request: protos.google.container.v1.IGetOperationRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IGetOperationRequest | undefined, {} | undefined]>;
+    getOperation(request: protos.google.container.v1.IGetOperationRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IGetOperationRequest | null | undefined, {} | null | undefined>): void;
+    getOperation(request: protos.google.container.v1.IGetOperationRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IGetOperationRequest | null | undefined, {} | null | undefined>): void;
+    cancelOperation(request: protos.google.container.v1.ICancelOperationRequest, options?: gax.CallOptions): Promise<[protos.google.protobuf.IEmpty, protos.google.container.v1.ICancelOperationRequest | undefined, {} | undefined]>;
+    cancelOperation(request: protos.google.container.v1.ICancelOperationRequest, options: gax.CallOptions, callback: Callback<protos.google.protobuf.IEmpty, protos.google.container.v1.ICancelOperationRequest | null | undefined, {} | null | undefined>): void;
+    cancelOperation(request: protos.google.container.v1.ICancelOperationRequest, callback: Callback<protos.google.protobuf.IEmpty, protos.google.container.v1.ICancelOperationRequest | null | undefined, {} | null | undefined>): void;
+    getServerConfig(request: protos.google.container.v1.IGetServerConfigRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IServerConfig, protos.google.container.v1.IGetServerConfigRequest | undefined, {} | undefined]>;
+    getServerConfig(request: protos.google.container.v1.IGetServerConfigRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IServerConfig, protos.google.container.v1.IGetServerConfigRequest | null | undefined, {} | null | undefined>): void;
+    getServerConfig(request: protos.google.container.v1.IGetServerConfigRequest, callback: Callback<protos.google.container.v1.IServerConfig, protos.google.container.v1.IGetServerConfigRequest | null | undefined, {} | null | undefined>): void;
+    listNodePools(request: protos.google.container.v1.IListNodePoolsRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IListNodePoolsResponse, protos.google.container.v1.IListNodePoolsRequest | undefined, {} | undefined]>;
+    listNodePools(request: protos.google.container.v1.IListNodePoolsRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IListNodePoolsResponse, protos.google.container.v1.IListNodePoolsRequest | null | undefined, {} | null | undefined>): void;
+    listNodePools(request: protos.google.container.v1.IListNodePoolsRequest, callback: Callback<protos.google.container.v1.IListNodePoolsResponse, protos.google.container.v1.IListNodePoolsRequest | null | undefined, {} | null | undefined>): void;
+    getNodePool(request: protos.google.container.v1.IGetNodePoolRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.INodePool, protos.google.container.v1.IGetNodePoolRequest | undefined, {} | undefined]>;
+    getNodePool(request: protos.google.container.v1.IGetNodePoolRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.INodePool, protos.google.container.v1.IGetNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    getNodePool(request: protos.google.container.v1.IGetNodePoolRequest, callback: Callback<protos.google.container.v1.INodePool, protos.google.container.v1.IGetNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    createNodePool(request: protos.google.container.v1.ICreateNodePoolRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ICreateNodePoolRequest | undefined, {} | undefined]>;
+    createNodePool(request: protos.google.container.v1.ICreateNodePoolRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ICreateNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    createNodePool(request: protos.google.container.v1.ICreateNodePoolRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ICreateNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    deleteNodePool(request: protos.google.container.v1.IDeleteNodePoolRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IDeleteNodePoolRequest | undefined, {} | undefined]>;
+    deleteNodePool(request: protos.google.container.v1.IDeleteNodePoolRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IDeleteNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    deleteNodePool(request: protos.google.container.v1.IDeleteNodePoolRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IDeleteNodePoolRequest | null | undefined, {} | null | undefined>): void;
+    rollbackNodePoolUpgrade(request: protos.google.container.v1.IRollbackNodePoolUpgradeRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IRollbackNodePoolUpgradeRequest | undefined, {} | undefined]>;
+    rollbackNodePoolUpgrade(request: protos.google.container.v1.IRollbackNodePoolUpgradeRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IRollbackNodePoolUpgradeRequest | null | undefined, {} | null | undefined>): void;
+    rollbackNodePoolUpgrade(request: protos.google.container.v1.IRollbackNodePoolUpgradeRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IRollbackNodePoolUpgradeRequest | null | undefined, {} | null | undefined>): void;
+    setNodePoolManagement(request: protos.google.container.v1.ISetNodePoolManagementRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolManagementRequest | undefined, {} | undefined]>;
+    setNodePoolManagement(request: protos.google.container.v1.ISetNodePoolManagementRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolManagementRequest | null | undefined, {} | null | undefined>): void;
+    setNodePoolManagement(request: protos.google.container.v1.ISetNodePoolManagementRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolManagementRequest | null | undefined, {} | null | undefined>): void;
+    setLabels(request: protos.google.container.v1.ISetLabelsRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetLabelsRequest | undefined, {} | undefined]>;
+    setLabels(request: protos.google.container.v1.ISetLabelsRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLabelsRequest | null | undefined, {} | null | undefined>): void;
+    setLabels(request: protos.google.container.v1.ISetLabelsRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLabelsRequest | null | undefined, {} | null | undefined>): void;
+    setLegacyAbac(request: protos.google.container.v1.ISetLegacyAbacRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetLegacyAbacRequest | undefined, {} | undefined]>;
+    setLegacyAbac(request: protos.google.container.v1.ISetLegacyAbacRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLegacyAbacRequest | null | undefined, {} | null | undefined>): void;
+    setLegacyAbac(request: protos.google.container.v1.ISetLegacyAbacRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetLegacyAbacRequest | null | undefined, {} | null | undefined>): void;
+    startIPRotation(request: protos.google.container.v1.IStartIPRotationRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.IStartIPRotationRequest | undefined, {} | undefined]>;
+    startIPRotation(request: protos.google.container.v1.IStartIPRotationRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IStartIPRotationRequest | null | undefined, {} | null | undefined>): void;
+    startIPRotation(request: protos.google.container.v1.IStartIPRotationRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.IStartIPRotationRequest | null | undefined, {} | null | undefined>): void;
+    completeIPRotation(request: protos.google.container.v1.ICompleteIPRotationRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ICompleteIPRotationRequest | undefined, {} | undefined]>;
+    completeIPRotation(request: protos.google.container.v1.ICompleteIPRotationRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ICompleteIPRotationRequest | null | undefined, {} | null | undefined>): void;
+    completeIPRotation(request: protos.google.container.v1.ICompleteIPRotationRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ICompleteIPRotationRequest | null | undefined, {} | null | undefined>): void;
+    setNodePoolSize(request: protos.google.container.v1.ISetNodePoolSizeRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolSizeRequest | undefined, {} | undefined]>;
+    setNodePoolSize(request: protos.google.container.v1.ISetNodePoolSizeRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolSizeRequest | null | undefined, {} | null | undefined>): void;
+    setNodePoolSize(request: protos.google.container.v1.ISetNodePoolSizeRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNodePoolSizeRequest | null | undefined, {} | null | undefined>): void;
+    setNetworkPolicy(request: protos.google.container.v1.ISetNetworkPolicyRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetNetworkPolicyRequest | undefined, {} | undefined]>;
+    setNetworkPolicy(request: protos.google.container.v1.ISetNetworkPolicyRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNetworkPolicyRequest | null | undefined, {} | null | undefined>): void;
+    setNetworkPolicy(request: protos.google.container.v1.ISetNetworkPolicyRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetNetworkPolicyRequest | null | undefined, {} | null | undefined>): void;
+    setMaintenancePolicy(request: protos.google.container.v1.ISetMaintenancePolicyRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IOperation, protos.google.container.v1.ISetMaintenancePolicyRequest | undefined, {} | undefined]>;
+    setMaintenancePolicy(request: protos.google.container.v1.ISetMaintenancePolicyRequest, options: gax.CallOptions, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetMaintenancePolicyRequest | null | undefined, {} | null | undefined>): void;
+    setMaintenancePolicy(request: protos.google.container.v1.ISetMaintenancePolicyRequest, callback: Callback<protos.google.container.v1.IOperation, protos.google.container.v1.ISetMaintenancePolicyRequest | null | undefined, {} | null | undefined>): void;
+    listUsableSubnetworks(request: protos.google.container.v1.IListUsableSubnetworksRequest, options?: gax.CallOptions): Promise<[protos.google.container.v1.IUsableSubnetwork[], protos.google.container.v1.IListUsableSubnetworksRequest | null, protos.google.container.v1.IListUsableSubnetworksResponse]>;
+    listUsableSubnetworks(request: protos.google.container.v1.IListUsableSubnetworksRequest, options: gax.CallOptions, callback: PaginationCallback<protos.google.container.v1.IListUsableSubnetworksRequest, protos.google.container.v1.IListUsableSubnetworksResponse | null | undefined, protos.google.container.v1.IUsableSubnetwork>): void;
+    listUsableSubnetworks(request: protos.google.container.v1.IListUsableSubnetworksRequest, callback: PaginationCallback<protos.google.container.v1.IListUsableSubnetworksRequest, protos.google.container.v1.IListUsableSubnetworksResponse | null | undefined, protos.google.container.v1.IUsableSubnetwork>): void;
+    /**
+     * Equivalent to {@link listUsableSubnetworks}, but returns a NodeJS Stream object.
+     *
+     * This fetches the paged responses for {@link listUsableSubnetworks} continuously
+     * and invokes the callback registered for 'data' event for each element in the
+     * responses.
+     *
+     * The returned object has 'end' method when no more elements are required.
+     *
+     * autoPaginate option will be ignored.
+     *
+     * @see {@link https://nodejs.org/api/stream.html}
+     *
+     * @param {Object} request
+     *   The request object that will be sent.
+     * @param {string} request.parent
+     *   The parent project where subnetworks are usable.
+     *   Specified in the format `projects/*`.
+     * @param {string} request.filter
+     *   Filtering currently only supports equality on the networkProjectId and must
+     *   be in the form: "networkProjectId=[PROJECTID]", where `networkProjectId`
+     *   is the project which owns the listed subnetworks. This defaults to the
+     *   parent project ID.
+     * @param {number} request.pageSize
+     *   The max number of results per page that should be returned. If the number
+     *   of available results is larger than `page_size`, a `next_page_token` is
+     *   returned which can be used to get the next page of results in subsequent
+     *   requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
+     * @param {string} request.pageToken
+     *   Specifies a page token to use. Set this to the nextPageToken returned by
+     *   previous list requests to get the next page of results.
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which emits an object representing [UsableSubnetwork]{@link google.container.v1.UsableSubnetwork} on 'data' event.
+     */
+    listUsableSubnetworksStream(request?: protos.google.container.v1.IListUsableSubnetworksRequest, options?: gax.CallOptions): Transform;
+    /**
+     * Equivalent to {@link listUsableSubnetworks}, but returns an iterable object.
+     *
+     * for-await-of syntax is used with the iterable to recursively get response element on-demand.
+     *
+     * @param {Object} request
+     *   The request object that will be sent.
+     * @param {string} request.parent
+     *   The parent project where subnetworks are usable.
+     *   Specified in the format `projects/*`.
+     * @param {string} request.filter
+     *   Filtering currently only supports equality on the networkProjectId and must
+     *   be in the form: "networkProjectId=[PROJECTID]", where `networkProjectId`
+     *   is the project which owns the listed subnetworks. This defaults to the
+     *   parent project ID.
+     * @param {number} request.pageSize
+     *   The max number of results per page that should be returned. If the number
+     *   of available results is larger than `page_size`, a `next_page_token` is
+     *   returned which can be used to get the next page of results in subsequent
+     *   requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
+     * @param {string} request.pageToken
+     *   Specifies a page token to use. Set this to the nextPageToken returned by
+     *   previous list requests to get the next page of results.
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Object}
+     *   An iterable Object that conforms to @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols.
+     */
+    listUsableSubnetworksAsync(request?: protos.google.container.v1.IListUsableSubnetworksRequest, options?: gax.CallOptions): AsyncIterable<protos.google.container.v1.IUsableSubnetwork>;
+    /**
+     * Terminate the GRPC channel and close the client.
+     *
+     * The client will no longer be usable and all future behavior is undefined.
+     */
+    close(): Promise<void>;
+}

--- a/generator/test/generators/googleCloud/generator.test.ts
+++ b/generator/test/generators/googleCloud/generator.test.ts
@@ -1,59 +1,158 @@
 import { expect } from "chai";
-import { extractClassBasedSDKData } from "../../../generators/googleCloud/generator";
-import { extractClientBasedSDKdata } from "../../../generators/googleCloud/generator";
+import {
+  extractClassBasedSDKData,
+  extractClientBasedSDKdata
+} from "../../../generators/googleCloud/generator";
+import { readJsonData, readSourceFile } from "../lib/helper";
+import { SyntaxKind } from "typescript";
 
 describe("GCP generator extractClassBasedSDKData", () => {
   context("with valid methods and valid AST", () => {
-    it("should class data", () => {
-      const result = extractClassBasedSDKData("", "");
+    it("should return class data", async () => {
+      const methods: any = await readJsonData(
+        "validDataset_1",
+        "googleCloud",
+        "methods"
+      );
+
+      const sdkFiles: any = await readJsonData(
+        "validDataset_1",
+        "googleCloud",
+        "files"
+      );
+
+      await Promise.all(
+        sdkFiles.map(async file => {
+          file.classes = [];
+          const sdkFile: any = await readSourceFile(
+            "validDataset_1",
+            "googleCloud"
+          );
+          sdkFile.forEachChild(child => {
+            if (SyntaxKind[child.kind] === "ClassDeclaration") {
+              let cloned = Object.assign({}, child);
+              file.classes.push(cloned);
+            }
+          });
+        })
+      );
+
+      extractClassBasedSDKData(methods, sdkFiles).then(result => {
+        expect(result).to.be.an("object");
+        expect(result.methods).to.be.an("array");
+      });
     });
   });
 
   context("with invalid AST", () => {
     it("should return Error", async () => {
-      try {
-        extractClassBasedSDKData("", "");
-      } catch (error) {
-        expect(error.message).to.eql("");
-      }
-    });
-  });
+      const methods: any = await readJsonData(
+        "invalidDataset_1",
+        "googleCloud",
+        "methods"
+      );
 
-  context("with invalid method data", () => {
-    it("should return Error", async () => {
-      try {
-        extractClassBasedSDKData("", "");
-      } catch (error) {
-        expect(error.message).to.eql("");
-      }
+      const sdkFiles: any = await readJsonData(
+        "invalidDataset_1",
+        "googleCloud",
+        "files"
+      );
+
+      await Promise.all(
+        sdkFiles.map(async file => {
+          file.classes = [];
+          const sdkFile: any = await readSourceFile(
+            "invalidDataset_1",
+            "googleCloud"
+          );
+          sdkFile.forEachChild(child => {
+            if (SyntaxKind[child.kind] === "ClassDeclaration") {
+              let cloned = Object.assign({}, child);
+              file.classes.push(cloned);
+            }
+          });
+        })
+      );
+
+      extractClassBasedSDKData(methods, sdkFiles).then(
+        result => {},
+        error => {
+          expect(error.message).to.eql("Data extraction unsuccessful");
+        }
+      );
     });
   });
 });
 
 describe("GCP generator extractClientBasedSDKdata", () => {
   context("with valid methods and valid AST", () => {
-    it("should class data", () => {
-      const result = extractClientBasedSDKdata("", "");
+    it("should return class data", async () => {
+      const methods: any = await readJsonData(
+        "validDataset_2",
+        "googleCloud",
+        "methods"
+      );
+
+      const sdkFiles: any = await readJsonData(
+        "validDataset_2",
+        "googleCloud",
+        "files"
+      );
+
+      await Promise.all(
+        sdkFiles.map(async file => {
+          const sdkFile: any = await readSourceFile(
+            "validDataset_2",
+            "googleCloud"
+          );
+          sdkFile.forEachChild(child => {
+            if (SyntaxKind[child.kind] === "ClassDeclaration") {
+              file.ast = Object.assign({}, child);
+            }
+          });
+        })
+      );
+
+      extractClientBasedSDKdata(methods, sdkFiles).then(result => {
+        expect(result).to.be.an("array");
+      });
     });
   });
 
   context("with invalid AST", () => {
     it("should return Error", async () => {
-      try {
-        extractClientBasedSDKdata("", "");
-      } catch (error) {
-        expect(error.message).to.eql("");
-      }
-    });
-  });
+      const methods: any = await readJsonData(
+        "invalidDataset_2",
+        "googleCloud",
+        "methods"
+      );
 
-  context("with invalid method data", () => {
-    it("should return Error", async () => {
-      try {
-        extractClientBasedSDKdata("", "");
-      } catch (error) {
-        expect(error.message).to.eql("");
-      }
+      const sdkFiles: any = await readJsonData(
+        "invalidDataset_2",
+        "googleCloud",
+        "files"
+      );
+
+      await Promise.all(
+        sdkFiles.map(async file => {
+          const sdkFile: any = await readSourceFile(
+            "invalidDataset_2",
+            "googleCloud"
+          );
+          sdkFile.forEachChild(child => {
+            if (SyntaxKind[child.kind] === "ClassDeclaration") {
+              file.ast = Object.assign({}, child);
+            }
+          });
+        })
+      );
+
+      extractClientBasedSDKdata(methods, sdkFiles).then(
+        result => {},
+        error => {
+          expect(error.message).to.eql("Data extraction unsuccessful");
+        }
+      );
     });
   });
 });

--- a/generator/test/generators/googleCloud/generator.test.ts
+++ b/generator/test/generators/googleCloud/generator.test.ts
@@ -1,0 +1,59 @@
+import { expect } from "chai";
+import { extractClassBasedSDKData } from "../../../generators/googleCloud/generator";
+import { extractClientBasedSDKdata } from "../../../generators/googleCloud/generator";
+
+describe("GCP generator extractClassBasedSDKData", () => {
+  context("with valid methods and valid AST", () => {
+    it("should class data", () => {
+      const result = extractClassBasedSDKData("", "");
+    });
+  });
+
+  context("with invalid AST", () => {
+    it("should return Error", async () => {
+      try {
+        extractClassBasedSDKData("", "");
+      } catch (error) {
+        expect(error.message).to.eql("");
+      }
+    });
+  });
+
+  context("with invalid method data", () => {
+    it("should return Error", async () => {
+      try {
+        extractClassBasedSDKData("", "");
+      } catch (error) {
+        expect(error.message).to.eql("");
+      }
+    });
+  });
+});
+
+describe("GCP generator extractClientBasedSDKdata", () => {
+  context("with valid methods and valid AST", () => {
+    it("should class data", () => {
+      const result = extractClientBasedSDKdata("", "");
+    });
+  });
+
+  context("with invalid AST", () => {
+    it("should return Error", async () => {
+      try {
+        extractClientBasedSDKdata("", "");
+      } catch (error) {
+        expect(error.message).to.eql("");
+      }
+    });
+  });
+
+  context("with invalid method data", () => {
+    it("should return Error", async () => {
+      try {
+        extractClientBasedSDKdata("", "");
+      } catch (error) {
+        expect(error.message).to.eql("");
+      }
+    });
+  });
+});

--- a/generator/test/generators/lib/helper.ts
+++ b/generator/test/generators/lib/helper.ts
@@ -1,0 +1,35 @@
+import * as fs from "fs";
+import { ScriptTarget, createSourceFile } from "typescript";
+
+export function readSourceFile(datasetName, provider) {
+  return new Promise((resolve, reject) => {
+    try {
+      const testFile =
+        process.cwd() +
+        `/test/generators/${provider}/dummyData/${datasetName}/sdkFile.txt`;
+      const testAST = createSourceFile(
+        testFile,
+        fs.readFileSync(testFile).toString(),
+        ScriptTarget.Latest,
+        true
+      );
+      resolve(testAST);
+    } catch (error) {
+      console.error(error);
+    }
+  });
+}
+
+export function readJsonData(datasetName, provider, fileName) {
+  return new Promise((resolve, reject) => {
+    try {
+      const testFile =
+        process.cwd() +
+        `/test/generators/${provider}/dummyData/${datasetName}/${fileName}.json`;
+      const testData = JSON.parse(fs.readFileSync(testFile, "utf8"));
+      resolve(testData);
+    } catch (error) {
+      console.error(error);
+    }
+  });
+}


### PR DESCRIPTION
Fixes #57 

## Proposed Changes

  - Isolating the data extraction process as a unit
  - Writing unit tests for generators
# Other 
* Execute  `yarn workspace class-generator run test` to run tests related to the generator 
