### PR TITLE
Addition of the Aluyin parser

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
 node_modules
 dist
 coverage
+generator/**/*.yml
+*.yml

--- a/generator/generators/aliyun/generator.ts
+++ b/generator/generators/aliyun/generator.ts
@@ -1,4 +1,4 @@
-import { getAST } from '../../parsers/aliyun/parser';
+import { ClassData, extractSDKData, getAST } from '../../parsers/aliyun/parser';
 
 export const generateAliyunClass = (
 	serviceClass: unknown,
@@ -8,7 +8,15 @@ export const generateAliyunClass = (
 	getAST(sdkfile)
 		.then(async result => {
 			const sdkClassAst = result;
-			console.log(sdkClassAst);
+			try {
+				const classData: ClassData = extractSDKData(
+					sdkClassAst,
+					serviceClass
+				);
+				classData.serviceName = serviceName;
+			} catch (err) {
+				console.error('Error : ', err);
+			}
 		})
 		.catch(error => {
 			console.error('Error : ', error);

--- a/generator/generators/aliyun/generator.ts
+++ b/generator/generators/aliyun/generator.ts
@@ -1,0 +1,16 @@
+import { getAST } from '../../parsers/aliyun/parser';
+
+export const generateAliyunClass = (
+	serviceClass: unknown,
+	serviceName: string
+) => {
+	const sdkfile = serviceClass[Object.keys(serviceClass)[0]];
+	getAST(sdkfile)
+		.then(async result => {
+			const sdkClassAst = result;
+			console.log(sdkClassAst);
+		})
+		.catch(error => {
+			console.error('Error : ', error);
+		});
+};

--- a/generator/generators/aws/generator.ts
+++ b/generator/generators/aws/generator.ts
@@ -1,125 +1,133 @@
-import * as fs from "fs";
-import { createSourceFile, ScriptTarget, SyntaxKind } from "typescript";
+import * as fs from 'fs';
+import { createSourceFile, ScriptTarget, SyntaxKind } from 'typescript';
 
-import { getAST } from "../../parsers/aws/parser";
-import { transform } from "../../transformers/aws/transformer";
-import { filters, getDir,groupers, printFile } from "../lib/helper";
+import { getAST } from '../../parsers/aws/parser';
+import { transform } from '../../transformers/aws/transformer';
+import { filters, getDir, groupers, printFile } from '../lib/helper';
 
 interface FunctionData {
-  functionName: string;
-  SDKFunctionName: string;
-  params: param[];
+	functionName: string;
+	SDKFunctionName: string;
+	params: param[];
 }
 
 interface param {
-  name: string;
-  type: string;
-  typeName: string;
+	name: string;
+	type: string;
+	typeName: string;
 }
 
 interface ClassData {
-  className: string;
-  functions: FunctionData[];
-  serviceName: string;
+	className: string;
+	functions: FunctionData[];
+	serviceName: string;
 }
 
-const dummyFile = process.cwd() + "/dummyClasses/aws.js";
+const dummyFile = process.cwd() + '/dummyClasses/aws.js';
 const dummyAst = createSourceFile(
-  dummyFile,
-  fs.readFileSync(dummyFile).toString(),
-  ScriptTarget.Latest,
-  true
+	dummyFile,
+	fs.readFileSync(dummyFile).toString(),
+	ScriptTarget.Latest,
+	true
 );
 
 export function extractSDKData(sdkClassAst, serviceClass) {
-  let methods: FunctionData[] = [];
-  const functions = [];
+	let methods: FunctionData[] = [];
+	const functions = [];
 
-  Object.keys(serviceClass).map((key, index) => {
-    functions.push(serviceClass[key].split(" ")[1]);
-  });
+	Object.keys(serviceClass).map((key, index) => {
+		functions.push(serviceClass[key].split(' ')[1]);
+	});
 
-  sdkClassAst.members.map(method => {
-    if (method.name && functions.includes(method.name.text)) {
-      let name;
-      Object.keys(serviceClass).map((key, index) => {
-        if (serviceClass[key].split(" ")[1] === method.name.text) {
-          name = key;
-        }
-      });
+	sdkClassAst.members.map(method => {
+		if (method.name && functions.includes(method.name.text)) {
+			let name;
+			Object.keys(serviceClass).map((key, index) => {
+				if (serviceClass[key].split(' ')[1] === method.name.text) {
+					name = key;
+				}
+			});
 
-      const parameters = [];
-      method.parameters.map(param => {
-        if (param.name.text !== "callback") {
-          const parameter = {
-            name: param.name.text,
-            optional: param.questionToken ? true : false,
-            type: SyntaxKind[param.type.kind],
-            typeName: null
-          };
+			const parameters = [];
+			method.parameters.map(param => {
+				if (param.name.text !== 'callback') {
+					const parameter = {
+						name: param.name.text,
+						optional: param.questionToken ? true : false,
+						type: SyntaxKind[param.type.kind],
+						typeName: null,
+					};
 
-          if (parameter.type === "TypeReference" && param.type.typeName) {
-            parameter.typeName = param.type.typeName.right.text;
-          }
+					if (
+						parameter.type === 'TypeReference' &&
+						param.type.typeName
+					) {
+						parameter.typeName = param.type.typeName.right.text;
+					}
 
-          parameters.push(parameter);
-        }
-      });
+					parameters.push(parameter);
+				}
+			});
 
-      methods.push({
-        functionName: name.toString(),
-        SDKFunctionName: method.name.text.toString(),
-        params: parameters
-      });
-    }
-  });
+			methods.push({
+				functionName: name.toString(),
+				SDKFunctionName: method.name.text.toString(),
+				params: parameters,
+			});
+		}
+	});
 
-  const groupedMethods = groupers.aws(methods);
-  methods = filters.aws(groupedMethods);
+	const groupedMethods = groupers.aws(methods);
+	methods = filters.aws(groupedMethods);
 
-  const classData: ClassData = {
-    className: sdkClassAst.name.text,
-    functions: methods,
-    serviceName: null
-  };
+	const classData: ClassData = {
+		className: sdkClassAst.name.text,
+		functions: methods,
+		serviceName: null,
+	};
 
-  return classData;
+	return classData;
 }
 
 export function generateAWSClass(serviceClass, serviceName) {
-  const sdkFile = serviceClass[Object.keys(serviceClass)[0]].split(" ")[0];
-  getAST(sdkFile).then(async result => {
-    const sdkClassAst = result;
-    try {
-      const classData: ClassData = extractSDKData(sdkClassAst, serviceClass);
-      classData.serviceName = serviceName;
-      const output = await transform(dummyAst, classData);
-      let filePath;
-      const dir = getDir(serviceName);
-      if (!fs.existsSync(process.cwd() + "/generatedClasses/AWS/" + dir)) {
-        fs.mkdirSync(process.cwd() + "/generatedClasses/AWS/" + dir);
-      }
-      if (/^[A-Z]*$/.test(serviceName)) {
-        filePath =
-          process.cwd() +
-          "/generatedClasses/AWS/" +
-          dir +
-          "/aws-" +
-          serviceName +
-          ".js";
-      } else {
-        filePath =
-          process.cwd() +
-          "/generatedClasses/AWS/" +
-          dir +
-          "/aws-" +
-          serviceName.charAt(0).toLowerCase() +
-          serviceName.slice(1) +
-          ".js";
-      }
-      printFile(filePath, output);
-    } catch (e) {
-      console.error(e);
-    }
-  });
+	const sdkFile = serviceClass[Object.keys(serviceClass)[0]].split(' ')[0];
+	getAST(sdkFile).then(async result => {
+		const sdkClassAst = result;
+		try {
+			const classData: ClassData = extractSDKData(
+				sdkClassAst,
+				serviceClass
+			);
+			classData.serviceName = serviceName;
+			const output = await transform(dummyAst, classData);
+			let filePath;
+			const dir = getDir(serviceName);
+			if (
+				!fs.existsSync(process.cwd() + '/generatedClasses/AWS/' + dir)
+			) {
+				fs.mkdirSync(process.cwd() + '/generatedClasses/AWS/' + dir);
+			}
+			if (/^[A-Z]*$/.test(serviceName)) {
+				filePath =
+					process.cwd() +
+					'/generatedClasses/AWS/' +
+					dir +
+					'/aws-' +
+					serviceName +
+					'.js';
+			} else {
+				filePath =
+					process.cwd() +
+					'/generatedClasses/AWS/' +
+					dir +
+					'/aws-' +
+					serviceName.charAt(0).toLowerCase() +
+					serviceName.slice(1) +
+					'.js';
+			}
+			printFile(filePath, output);
+		} catch (e) {
+			console.error(e);
+		}
+	});
 }

--- a/generator/generators/azure/generator.ts
+++ b/generator/generators/azure/generator.ts
@@ -1,152 +1,152 @@
-import * as fs from "fs";
-import { createSourceFile, ScriptTarget,SyntaxKind } from "typescript";
+import * as fs from 'fs';
+import { createSourceFile, ScriptTarget, SyntaxKind } from 'typescript';
 
-import { getAST } from "../../parsers/azure/parser";
-import { transform } from "../../transformers/azure/transformer";
-import { filters, getDir,groupers, printFile } from "../lib/helper";
+import { getAST } from '../../parsers/azure/parser';
+import { transform } from '../../transformers/azure/transformer';
+import { filters, getDir, groupers, printFile } from '../lib/helper';
 
 interface FunctionData {
-  pkgName: string;
-  fileName: string;
-  functionName: string;
-  SDKFunctionName: string;
-  params: param[];
-  returnType: string;
-  client: string;
+	pkgName: string;
+	fileName: string;
+	functionName: string;
+	SDKFunctionName: string;
+	params: param[];
+	returnType: string;
+	client: string;
 }
 
 interface param {
-  name: string;
-  type: string;
+	name: string;
+	type: string;
 }
 
-const dummyFile = process.cwd() + "/dummyClasses/azure.js";
+const dummyFile = process.cwd() + '/dummyClasses/azure.js';
 const dummyAst = createSourceFile(
-  dummyFile,
-  fs.readFileSync(dummyFile).toString(),
-  ScriptTarget.Latest,
-  true
+	dummyFile,
+	fs.readFileSync(dummyFile).toString(),
+	ScriptTarget.Latest,
+	true
 );
 
 export function extractSDKData(sdkFiles, methods) {
-  const specifiedMethods = JSON.parse(JSON.stringify(methods));
-  sdkFiles.map(sdkFile => {
-    sdkFile.ast.members.map(member => {
-      if (SyntaxKind[member.kind] === "Constructor") {
-        member.parameters.map(param => {
-          const tempStr = param.type.typeName.text.split(/(?=[A-Z])/);
-          tempStr.pop();
-          sdkFile.client = tempStr.join("");
-        });
-      }
+	const specifiedMethods = JSON.parse(JSON.stringify(methods));
+	sdkFiles.map(sdkFile => {
+		sdkFile.ast.members.map(member => {
+			if (SyntaxKind[member.kind] === 'Constructor') {
+				member.parameters.map(param => {
+					const tempStr = param.type.typeName.text.split(/(?=[A-Z])/);
+					tempStr.pop();
+					sdkFile.client = tempStr.join('');
+				});
+			}
 
-      if (
-        SyntaxKind[member.kind] === "MethodDeclaration" &&
-        sdkFile.sdkFunctionNames.includes(member.name.text)
-      ) {
-        const method = methods.find(
-          methd =>
-            methd.SDKFunctionName === member.name.text &&
-            methd.fileName === sdkFile.fileName
-        );
-        const parameters = member.parameters.map(param => {
-          return {
-            name: param.name.text,
-            optional: param.questionToken ? true : false,
-            type: SyntaxKind[param.type.kind]
-          };
-        });
+			if (
+				SyntaxKind[member.kind] === 'MethodDeclaration' &&
+				sdkFile.sdkFunctionNames.includes(member.name.text)
+			) {
+				const method = methods.find(
+					methd =>
+						methd.SDKFunctionName === member.name.text &&
+						methd.fileName === sdkFile.fileName
+				);
+				const parameters = member.parameters.map(param => {
+					return {
+						name: param.name.text,
+						optional: param.questionToken ? true : false,
+						type: SyntaxKind[param.type.kind],
+					};
+				});
 
-        const returnType = SyntaxKind[member.type.kind];
-        if (!method.returnType) {
-          method.params = parameters;
-          method.returnType = returnType;
-          method.client = sdkFile.client;
-        } else {
-          const clone = JSON.parse(JSON.stringify(method));
-          clone.params = parameters;
-          clone.returnType = returnType;
-          clone.client = sdkFile.client;
-          methods.push(clone);
-        }
-      }
-    });
-  });
+				const returnType = SyntaxKind[member.type.kind];
+				if (!method.returnType) {
+					method.params = parameters;
+					method.returnType = returnType;
+					method.client = sdkFile.client;
+				} else {
+					const clone = JSON.parse(JSON.stringify(method));
+					clone.params = parameters;
+					clone.returnType = returnType;
+					clone.client = sdkFile.client;
+					methods.push(clone);
+				}
+			}
+		});
+	});
 
-  if (JSON.stringify(methods) === JSON.stringify(specifiedMethods)) {
-    throw new Error("Data extraction unsuccessful");
-  }
+	if (JSON.stringify(methods) === JSON.stringify(specifiedMethods)) {
+		throw new Error('Data extraction unsuccessful');
+	}
 
-  const groupedMethods = groupers.azure(methods);
-  methods = filters.azure(groupedMethods);
+	const groupedMethods = groupers.azure(methods);
+	methods = filters.azure(groupedMethods);
 
-  const classData = {
-    functions: methods
-  };
+	const classData = {
+		functions: methods,
+	};
 
-  return classData;
+	return classData;
 }
 
 export async function generateAzureClass(serviceClass, serviceName) {
-  let methods: FunctionData[] = [];
+	let methods: FunctionData[] = [];
 
-  Object.keys(serviceClass).map((key, index) => {
-    methods.push({
-      pkgName: serviceClass[key].split(" ")[0],
-      fileName: serviceClass[key].split(" ")[1],
-      functionName: key,
-      SDKFunctionName: serviceClass[key].split(" ")[2],
-      params: [],
-      returnType: null,
-      client: null
-    });
-  });
+	Object.keys(serviceClass).map((key, index) => {
+		methods.push({
+			pkgName: serviceClass[key].split(' ')[0],
+			fileName: serviceClass[key].split(' ')[1],
+			functionName: key,
+			SDKFunctionName: serviceClass[key].split(' ')[2],
+			params: [],
+			returnType: null,
+			client: null,
+		});
+	});
 
-  const files = Array.from(new Set(methods.map(method => method.fileName)));
+	const files = Array.from(new Set(methods.map(method => method.fileName)));
 
-  const sdkFiles = files.map(file => {
-    return {
-      fileName: file,
-      pkgName: methods[0].pkgName,
-      ast: null,
-      client: null,
-      sdkFunctionNames: methods
-        .filter(method => method.fileName === file)
-        .map(method => method.SDKFunctionName)
-    };
-  });
+	const sdkFiles = files.map(file => {
+		return {
+			fileName: file,
+			pkgName: methods[0].pkgName,
+			ast: null,
+			client: null,
+			sdkFunctionNames: methods
+				.filter(method => method.fileName === file)
+				.map(method => method.SDKFunctionName),
+		};
+	});
 
-  await Promise.all(
-    sdkFiles.map(async file => {
-      file.ast = await getAST(file);
-    })
-  );
+	await Promise.all(
+		sdkFiles.map(async file => {
+			file.ast = await getAST(file);
+		})
+	);
 
-  const classData: any = extractSDKData(sdkFiles, methods);
-  classData.serviceName = serviceName;
-  const output = await transform(dummyAst, classData);
-  let filePath;
-  const dir = getDir(serviceName);
-  if (!fs.existsSync(process.cwd() + "/generatedClasses/Azure/" + dir)) {
-    fs.mkdirSync(process.cwd() + "/generatedClasses/Azure/" + dir);
-  }
-  if (/^[A-Z]*$/.test(serviceName)) {
-    filePath =
-      process.cwd() +
-      "/generatedClasses/Azure/" +
-      dir +
-      "/azure-" +
-      serviceName +
-      ".js";
-  } else {
-    filePath =
-      process.cwd() +
-      "/generatedClasses/Azure/" +
-      dir +
-      "/azure-" +
-      serviceName.charAt(0).toLowerCase() +
-      serviceName.slice(1) +
-      ".js";
-  }
-  printFile(filePath, output);
+	const classData: any = extractSDKData(sdkFiles, methods);
+	classData.serviceName = serviceName;
+	const output = await transform(dummyAst, classData);
+	let filePath;
+	const dir = getDir(serviceName);
+	if (!fs.existsSync(process.cwd() + '/generatedClasses/Azure/' + dir)) {
+		fs.mkdirSync(process.cwd() + '/generatedClasses/Azure/' + dir);
+	}
+	if (/^[A-Z]*$/.test(serviceName)) {
+		filePath =
+			process.cwd() +
+			'/generatedClasses/Azure/' +
+			dir +
+			'/azure-' +
+			serviceName +
+			'.js';
+	} else {
+		filePath =
+			process.cwd() +
+			'/generatedClasses/Azure/' +
+			dir +
+			'/azure-' +
+			serviceName.charAt(0).toLowerCase() +
+			serviceName.slice(1) +
+			'.js';
+	}
+	printFile(filePath, output);
 }

--- a/generator/generators/do/generator.ts
+++ b/generator/generators/do/generator.ts
@@ -1,123 +1,129 @@
-import * as fs from "fs";
-import { createSourceFile, ScriptTarget, SyntaxKind } from "typescript";
+import * as fs from 'fs';
+import { createSourceFile, ScriptTarget, SyntaxKind } from 'typescript';
 
-import { getAST } from "../../parsers/do/parser";
-import { transform } from "../../transformers/do/transformer";
-import { getDir,printFile } from "../lib/helper";
+import { getAST } from '../../parsers/do/parser';
+import { transform } from '../../transformers/do/transformer';
+import { getDir, printFile } from '../lib/helper';
 
 interface FunctionData {
-  functionName: string;
-  SDKFunctionName: string;
-  params: param[];
+	functionName: string;
+	SDKFunctionName: string;
+	params: param[];
 }
 
 interface param {
-  name: string;
-  type: string;
-  typeName: string;
+	name: string;
+	type: string;
+	typeName: string;
 }
 
 interface ClassData {
-  className: string;
-  functions: FunctionData[];
-  serviceName: string;
+	className: string;
+	functions: FunctionData[];
+	serviceName: string;
 }
 
-const dummyFile = process.cwd() + "/dummyClasses/do.js";
+const dummyFile = process.cwd() + '/dummyClasses/do.js';
 
 const dummyAst = createSourceFile(
-  dummyFile,
-  fs.readFileSync(dummyFile).toString(),
-  ScriptTarget.Latest,
-  true
+	dummyFile,
+	fs.readFileSync(dummyFile).toString(),
+	ScriptTarget.Latest,
+	true
 );
 
 export function extractSDKData(sdkClassAst, serviceClass) {
-  let methods: FunctionData[] = [];
-  const functions = [];
+	let methods: FunctionData[] = [];
+	const functions = [];
 
-  Object.keys(serviceClass).map((key, index) => {
-    functions.push(serviceClass[key].split(" ")[1]);
-  });
+	Object.keys(serviceClass).map((key, index) => {
+		functions.push(serviceClass[key].split(' ')[1]);
+	});
 
-  sdkClassAst.members.map(method => {
-    if (method.name && functions.includes(method.name.text)) {
-      let name;
-      Object.keys(serviceClass).map((key, index) => {
-        if (serviceClass[key].split(" ")[1] === method.name.text) {
-          name = key;
-        }
-      });
+	sdkClassAst.members.map(method => {
+		if (method.name && functions.includes(method.name.text)) {
+			let name;
+			Object.keys(serviceClass).map((key, index) => {
+				if (serviceClass[key].split(' ')[1] === method.name.text) {
+					name = key;
+				}
+			});
 
-      const parameters = [];
-      method.parameters.map(param => {
-        if (param.name.text !== "callback") {
-          const parameter = {
-            name: param.name.text,
-            optional: param.questionToken ? true : false,
-            type: SyntaxKind[param.type.kind],
-            typeName: null
-          };
+			const parameters = [];
+			method.parameters.map(param => {
+				if (param.name.text !== 'callback') {
+					const parameter = {
+						name: param.name.text,
+						optional: param.questionToken ? true : false,
+						type: SyntaxKind[param.type.kind],
+						typeName: null,
+					};
 
-          if (parameter.type === "TypeReference" && param.type.typeName) {
-            parameter.typeName = param.type.typeName.text;
-          }
+					if (
+						parameter.type === 'TypeReference' &&
+						param.type.typeName
+					) {
+						parameter.typeName = param.type.typeName.text;
+					}
 
-          parameters.push(parameter);
-        }
-      });
+					parameters.push(parameter);
+				}
+			});
 
-      methods.push({
-        functionName: name.toString(),
-        SDKFunctionName: method.name.text.toString(),
-        params: parameters
-      });
-    }
-  });
+			methods.push({
+				functionName: name.toString(),
+				SDKFunctionName: method.name.text.toString(),
+				params: parameters,
+			});
+		}
+	});
 
-  const classData: ClassData = {
-    className: sdkClassAst.name.text,
-    functions: methods,
-    serviceName: null
-  };
+	const classData: ClassData = {
+		className: sdkClassAst.name.text,
+		functions: methods,
+		serviceName: null,
+	};
 
-  return classData;
+	return classData;
 }
 
 export function generateDOClass(serviceClass, serviceName) {
-  const sdkFile = serviceClass[Object.keys(serviceClass)[0]].split(" ")[0];
-  getAST(sdkFile).then(async result => {
-    const sdkClassAst = result;
-    try {
-      const classData: ClassData = extractSDKData(sdkClassAst, serviceClass);
-      classData.serviceName = serviceName;
-      const output = await transform(dummyAst, classData);
-      let filePath;
-      const dir = getDir(serviceName);
-      if (!fs.existsSync(process.cwd() + "/generatedClasses/DO/" + dir)) {
-        fs.mkdirSync(process.cwd() + "/generatedClasses/DO/" + dir);
-      }
-      if (/^[A-Z]*$/.test(serviceName)) {
-        filePath =
-          process.cwd() +
-          "/generatedClasses/DO/" +
-          dir +
-          "/do-" +
-          serviceName +
-          ".js";
-      } else {
-        filePath =
-          process.cwd() +
-          "/generatedClasses/DO/" +
-          dir +
-          "/do-" +
-          serviceName.charAt(0).toLowerCase() +
-          serviceName.slice(1) +
-          ".js";
-      }
-      printFile(filePath, output);
-    } catch (e) {
-      console.error(e);
-    }
-  });
+	const sdkFile = serviceClass[Object.keys(serviceClass)[0]].split(' ')[0];
+	getAST(sdkFile).then(async result => {
+		const sdkClassAst = result;
+		try {
+			const classData: ClassData = extractSDKData(
+				sdkClassAst,
+				serviceClass
+			);
+			classData.serviceName = serviceName;
+			const output = await transform(dummyAst, classData);
+			let filePath;
+			const dir = getDir(serviceName);
+			if (!fs.existsSync(process.cwd() + '/generatedClasses/DO/' + dir)) {
+				fs.mkdirSync(process.cwd() + '/generatedClasses/DO/' + dir);
+			}
+			if (/^[A-Z]*$/.test(serviceName)) {
+				filePath =
+					process.cwd() +
+					'/generatedClasses/DO/' +
+					dir +
+					'/do-' +
+					serviceName +
+					'.js';
+			} else {
+				filePath =
+					process.cwd() +
+					'/generatedClasses/DO/' +
+					dir +
+					'/do-' +
+					serviceName.charAt(0).toLowerCase() +
+					serviceName.slice(1) +
+					'.js';
+			}
+			printFile(filePath, output);
+		} catch (e) {
+			console.error(e);
+		}
+	});
 }

--- a/generator/generators/googleCloud/generator.ts
+++ b/generator/generators/googleCloud/generator.ts
@@ -1,388 +1,405 @@
-import * as fs from "fs";
-import * as path from "path";
-import { createSourceFile, ScriptTarget,SyntaxKind } from "typescript";
+import * as fs from 'fs';
+import * as path from 'path';
+import { createSourceFile, ScriptTarget, SyntaxKind } from 'typescript';
 
-import { getAST } from "../../parsers/googleCloud/parser";
-import { classBasedTransform } from "../../transformers/googleCloud/classBasedTransformer";
-import { clientBasedTransform } from "../../transformers/googleCloud/clientBasedTransformer";
-import { filters, getDir,groupers, printFile } from "../lib/helper";
+import { getAST } from '../../parsers/googleCloud/parser';
+import { classBasedTransform } from '../../transformers/googleCloud/classBasedTransformer';
+import { clientBasedTransform } from '../../transformers/googleCloud/clientBasedTransformer';
+import { filters, getDir, groupers, printFile } from '../lib/helper';
 
 interface ClassData {
-  name: string;
-  methods: FunctionData[];
-  constructor: constructorData;
-  properties: propertyData[];
+	name: string;
+	methods: FunctionData[];
+	constructor: constructorData;
+	properties: propertyData[];
 }
 
 interface FunctionData {
-  pkgName: string;
-  version: string;
-  fileName: string;
-  functionName: string;
-  SDKFunctionName: string;
-  params: param[];
-  returnType: string;
-  returnTypeName: string;
-  client: string;
+	pkgName: string;
+	version: string;
+	fileName: string;
+	functionName: string;
+	SDKFunctionName: string;
+	params: param[];
+	returnType: string;
+	returnTypeName: string;
+	client: string;
 }
 
 interface propertyData {
-  name: string;
-  type: string;
+	name: string;
+	type: string;
 }
 
 interface constructorData {
-  parameters: param[];
+	parameters: param[];
 }
 
 interface param {
-  name: string;
-  type: string;
-  optional: boolean;
+	name: string;
+	type: string;
+	optional: boolean;
 }
 
-const dummyFile = process.cwd() + "/dummyClasses/gcp.js";
+const dummyFile = process.cwd() + '/dummyClasses/gcp.js';
 const dummyAst = createSourceFile(
-  dummyFile,
-  fs.readFileSync(dummyFile).toString(),
-  ScriptTarget.Latest,
-  true
+	dummyFile,
+	fs.readFileSync(dummyFile).toString(),
+	ScriptTarget.Latest,
+	true
 );
 
 export function extractClassBasedSDKData(methods, sdkFiles): any {
-  const specifiedMethods = JSON.parse(JSON.stringify(methods));
-  return new Promise(async (resolve, reject) => {
-    try {
-      let classes: ClassData[] = [];
+	const specifiedMethods = JSON.parse(JSON.stringify(methods));
+	return new Promise(async (resolve, reject) => {
+		try {
+			let classes: ClassData[] = [];
 
-      sdkFiles.map(file => {
-        file.classes.map(classAst => {
-          const classInfo: ClassData = {
-            name: classAst.name.text,
-            methods: [],
-            properties: [],
-            constructor: null
-          };
+			sdkFiles.map(file => {
+				file.classes.map(classAst => {
+					const classInfo: ClassData = {
+						name: classAst.name.text,
+						methods: [],
+						properties: [],
+						constructor: null,
+					};
 
-          classAst.members.map(member => {
-            if (SyntaxKind[member.kind] === "MethodDeclaration") {
-              const returnType = SyntaxKind[member.type.kind];
+					classAst.members.map(member => {
+						if (SyntaxKind[member.kind] === 'MethodDeclaration') {
+							const returnType = SyntaxKind[member.type.kind];
 
-              const parameters = member.parameters.map(param => {
-                return {
-                  name: param.name.text,
-                  optional: param.questionToken ? true : false,
-                  type: SyntaxKind[param.type.kind]
-                };
-              });
-              const method: FunctionData = {
-                pkgName: file.pkgName,
-                version: null,
-                fileName: file.fileName,
-                functionName: null,
-                SDKFunctionName: member.name.text,
-                params: parameters,
-                returnType: returnType,
-                returnTypeName: null,
-                client: classAst.name.text // Class name
-              };
+							const parameters = member.parameters.map(param => {
+								return {
+									name: param.name.text,
+									optional: param.questionToken
+										? true
+										: false,
+									type: SyntaxKind[param.type.kind],
+								};
+							});
+							const method: FunctionData = {
+								pkgName: file.pkgName,
+								version: null,
+								fileName: file.fileName,
+								functionName: null,
+								SDKFunctionName: member.name.text,
+								params: parameters,
+								returnType: returnType,
+								returnTypeName: null,
+								client: classAst.name.text, // Class name
+							};
 
-              if (returnType === "TypeReference") {
-                method.returnTypeName = member.type.typeName.text;
-              }
+							if (returnType === 'TypeReference') {
+								method.returnTypeName =
+									member.type.typeName.text;
+							}
 
-              const meth = methods.find(
-                meth =>
-                  meth.SDKFunctionName === method.SDKFunctionName &&
-                  meth.fileName === method.fileName
-              );
-              method.functionName = meth ? meth.functionName : null;
-              classInfo.methods.push(method);
-            }
+							const meth = methods.find(
+								meth =>
+									meth.SDKFunctionName ===
+										method.SDKFunctionName &&
+									meth.fileName === method.fileName
+							);
+							method.functionName = meth
+								? meth.functionName
+								: null;
+							classInfo.methods.push(method);
+						}
 
-            if (SyntaxKind[member.kind] === "Constructor") {
-              const parameters = member.parameters.map(param => {
-                return {
-                  name: param.name.text,
-                  optional: param.questionToken ? true : false,
-                  type: SyntaxKind[param.type.kind],
-                  typeRefName: param.type.typeName
-                    ? param.type.typeName.text
-                    : null
-                };
-              });
+						if (SyntaxKind[member.kind] === 'Constructor') {
+							const parameters = member.parameters.map(param => {
+								return {
+									name: param.name.text,
+									optional: param.questionToken
+										? true
+										: false,
+									type: SyntaxKind[param.type.kind],
+									typeRefName: param.type.typeName
+										? param.type.typeName.text
+										: null,
+								};
+							});
 
-              classInfo.constructor = {
-                parameters
-              };
-            }
+							classInfo.constructor = {
+								parameters,
+							};
+						}
 
-            if (SyntaxKind[member.kind] === "PropertyDeclaration") {
-              const isPrivateProp =
-                member.modifiers &&
-                member.modifiers.some(
-                  modifier => SyntaxKind[modifier.kind] === "PrivateKeyword"
-                );
-              if (!isPrivateProp) {
-                const prop = {
-                  name: member.name.text,
-                  type: SyntaxKind[member.type.kind],
-                  typeRefName: member.type.typeName
-                    ? member.type.typeName.text
-                    : null
-                };
-                classInfo.properties.push(prop);
-              }
-            }
-          });
-          classes.push(classInfo);
-        });
-      });
+						if (SyntaxKind[member.kind] === 'PropertyDeclaration') {
+							const isPrivateProp =
+								member.modifiers &&
+								member.modifiers.some(
+									modifier =>
+										SyntaxKind[modifier.kind] ===
+										'PrivateKeyword'
+								);
+							if (!isPrivateProp) {
+								const prop = {
+									name: member.name.text,
+									type: SyntaxKind[member.type.kind],
+									typeRefName: member.type.typeName
+										? member.type.typeName.text
+										: null,
+								};
+								classInfo.properties.push(prop);
+							}
+						}
+					});
+					classes.push(classInfo);
+				});
+			});
 
-      methods = [];
+			methods = [];
 
-      classes.map(classData => {
-        let filteredMethods: any = classData.methods.filter(
-          meth => meth.functionName !== null
-        );
-        filteredMethods.map(filMeth => {
-          filMeth.classConstructorData = classData.constructor;
-        });
+			classes.map(classData => {
+				let filteredMethods: any = classData.methods.filter(
+					meth => meth.functionName !== null
+				);
+				filteredMethods.map(filMeth => {
+					filMeth.classConstructorData = classData.constructor;
+				});
 
-        methods = methods.concat(filteredMethods);
-      });
+				methods = methods.concat(filteredMethods);
+			});
 
-      const extractedData = {
-        classes,
-        methods
-      };
-      if (JSON.stringify(methods) === JSON.stringify(specifiedMethods)) {
-        reject(new Error("Data extraction unsuccessful"));
-      } else {
-        resolve(extractedData);
-      }
-    } catch (error) {
-      reject(error);
-    }
-  });
+			const extractedData = {
+				classes,
+				methods,
+			};
+			if (JSON.stringify(methods) === JSON.stringify(specifiedMethods)) {
+				reject(new Error('Data extraction unsuccessful'));
+			} else {
+				resolve(extractedData);
+			}
+		} catch (error) {
+			reject(error);
+		}
+	});
 }
 
 export function extractClientBasedSDKdata(methods, sdkFiles): any {
-  const specifiedMethods = JSON.parse(JSON.stringify(methods));
-  return new Promise(async (resolve, reject) => {
-    try {
-      sdkFiles.map(sdkFile => {
-        sdkFile.client = sdkFile.ast.name.text;
-        sdkFile.ast.members.map(member => {
-          if (
-            SyntaxKind[member.kind] === "MethodDeclaration" &&
-            sdkFile.sdkFunctionNames.includes(member.name.text)
-          ) {
-            const method = methods.find(
-              methd => methd.SDKFunctionName === member.name.text
-            );
+	const specifiedMethods = JSON.parse(JSON.stringify(methods));
+	return new Promise(async (resolve, reject) => {
+		try {
+			sdkFiles.map(sdkFile => {
+				sdkFile.client = sdkFile.ast.name.text;
+				sdkFile.ast.members.map(member => {
+					if (
+						SyntaxKind[member.kind] === 'MethodDeclaration' &&
+						sdkFile.sdkFunctionNames.includes(member.name.text)
+					) {
+						const method = methods.find(
+							methd => methd.SDKFunctionName === member.name.text
+						);
 
-            const parameters = member.parameters.map(param => {
-              return {
-                name: param.name.text,
-                optional: param.questionToken ? true : false,
-                type: SyntaxKind[param.type.kind]
-              };
-            });
+						const parameters = member.parameters.map(param => {
+							return {
+								name: param.name.text,
+								optional: param.questionToken ? true : false,
+								type: SyntaxKind[param.type.kind],
+							};
+						});
 
-            const returnType = SyntaxKind[member.type.kind];
-            if (returnType === "TypeReference") {
-              method.returnTypeName = member.type.typeName.text;
-            }
+						const returnType = SyntaxKind[member.type.kind];
+						if (returnType === 'TypeReference') {
+							method.returnTypeName = member.type.typeName.text;
+						}
 
-            if (!method.returnType) {
-              method.params = parameters;
-              method.returnType = returnType;
-              method.client = sdkFile.client;
-            } else {
-              const clone = JSON.parse(JSON.stringify(method));
-              clone.params = parameters;
-              clone.returnType = returnType;
-              clone.client = sdkFile.client;
-              methods.push(clone);
-            }
-          }
-        });
-      });
+						if (!method.returnType) {
+							method.params = parameters;
+							method.returnType = returnType;
+							method.client = sdkFile.client;
+						} else {
+							const clone = JSON.parse(JSON.stringify(method));
+							clone.params = parameters;
+							clone.returnType = returnType;
+							clone.client = sdkFile.client;
+							methods.push(clone);
+						}
+					}
+				});
+			});
 
-      if (JSON.stringify(methods) === JSON.stringify(specifiedMethods)) {
-        reject(new Error("Data extraction unsuccessful"));
-      } else {
-        resolve(methods);
-      }
-    } catch (error) {
-      reject(error);
-    }
-  });
+			if (JSON.stringify(methods) === JSON.stringify(specifiedMethods)) {
+				reject(new Error('Data extraction unsuccessful'));
+			} else {
+				resolve(methods);
+			}
+		} catch (error) {
+			reject(error);
+		}
+	});
 }
 
 async function generateClassBasedCode(methods, data, serviceName) {
-  const dirPath = `../../../node_modules/@google-cloud/${methods[0].pkgName}/build/src/`;
-  let files = fs.readdirSync(path.join(__dirname, dirPath));
-  files = files.filter(
-    fileName =>
-      fileName.split(".")[1] === "d" && fileName.split(".")[2] === "ts"
-  );
+	const dirPath = `../../../node_modules/@google-cloud/${methods[0].pkgName}/build/src/`;
+	let files = fs.readdirSync(path.join(__dirname, dirPath));
+	files = files.filter(
+		fileName =>
+			fileName.split('.')[1] === 'd' && fileName.split('.')[2] === 'ts'
+	);
 
-  const sdkFiles = files.map(fileName => {
-    return {
-      fileName: fileName,
-      pkgName: methods[0].pkgName,
-      classes: null,
-      sdkFunctionNames: methods
-        .filter(method => method.fileName === <string>fileName)
-        .map(method => method.SDKFunctionName)
-    };
-  });
+	const sdkFiles = files.map(fileName => {
+		return {
+			fileName: fileName,
+			pkgName: methods[0].pkgName,
+			classes: null,
+			sdkFunctionNames: methods
+				.filter(method => method.fileName === <string>fileName)
+				.map(method => method.SDKFunctionName),
+		};
+	});
 
-  await Promise.all(
-    sdkFiles.map(async file => {
-      file.classes = await getAST(file, true);
-    })
-  );
+	await Promise.all(
+		sdkFiles.map(async file => {
+			file.classes = await getAST(file, true);
+		})
+	);
 
-  const extractedData = await extractClassBasedSDKData(methods, sdkFiles).then(
-    result => result
-  );
-  const groupedMethods = groupers.gcp(extractedData.methods);
-  methods = filters.gcp(groupedMethods);
-  data.functions = methods;
-  data.classData = extractedData.classes;
-  data.serviceName = serviceName;
+	const extractedData = await extractClassBasedSDKData(
+		methods,
+		sdkFiles
+	).then(result => result);
+	const groupedMethods = groupers.gcp(extractedData.methods);
+	methods = filters.gcp(groupedMethods);
+	data.functions = methods;
+	data.classData = extractedData.classes;
+	data.serviceName = serviceName;
 
-  const output = await classBasedTransform(dummyAst, data);
-  let filePath;
-  const dir = getDir(serviceName);
-  if (!fs.existsSync(process.cwd() + "/generatedClasses/googleCloud/" + dir)) {
-    fs.mkdirSync(process.cwd() + "/generatedClasses/googleCloud/" + dir);
-  }
-  if (/^[A-Z]*$/.test(serviceName)) {
-    filePath =
-      process.cwd() +
-      "/generatedClasses/googleCloud/" +
-      dir +
-      "/gcp-" +
-      serviceName +
-      ".js";
-  } else {
-    filePath =
-      process.cwd() +
-      "/generatedClasses/googleCloud/" +
-      dir +
-      "/gcp-" +
-      serviceName.charAt(0).toLowerCase() +
-      serviceName.slice(1) +
-      ".js";
-  }
-  printFile(filePath, output);
+	const output = await classBasedTransform(dummyAst, data);
+	let filePath;
+	const dir = getDir(serviceName);
+	if (
+		!fs.existsSync(process.cwd() + '/generatedClasses/googleCloud/' + dir)
+	) {
+		fs.mkdirSync(process.cwd() + '/generatedClasses/googleCloud/' + dir);
+	}
+	if (/^[A-Z]*$/.test(serviceName)) {
+		filePath =
+			process.cwd() +
+			'/generatedClasses/googleCloud/' +
+			dir +
+			'/gcp-' +
+			serviceName +
+			'.js';
+	} else {
+		filePath =
+			process.cwd() +
+			'/generatedClasses/googleCloud/' +
+			dir +
+			'/gcp-' +
+			serviceName.charAt(0).toLowerCase() +
+			serviceName.slice(1) +
+			'.js';
+	}
+	printFile(filePath, output);
 }
 
 async function generateClientBasedCode(methods, serviceName) {
-  const files = Array.from(
-    new Set(methods.map(method => method.fileName + " " + method.version))
-  );
-  const sdkFiles = files.map(file => {
-    return {
-      fileName: (<string>file).split(" ")[0],
-      version: (<string>file).split(" ")[1],
-      pkgName: methods[0].pkgName,
-      ast: null,
-      client: null,
-      sdkFunctionNames: methods
-        .filter(method => method.fileName === (<string>file).split(" ")[0])
-        .map(method => method.SDKFunctionName)
-    };
-  });
+	const files = Array.from(
+		new Set(methods.map(method => method.fileName + ' ' + method.version))
+	);
+	const sdkFiles = files.map(file => {
+		return {
+			fileName: (<string>file).split(' ')[0],
+			version: (<string>file).split(' ')[1],
+			pkgName: methods[0].pkgName,
+			ast: null,
+			client: null,
+			sdkFunctionNames: methods
+				.filter(
+					method => method.fileName === (<string>file).split(' ')[0]
+				)
+				.map(method => method.SDKFunctionName),
+		};
+	});
 
-  await Promise.all(
-    sdkFiles.map(async file => {
-      file.ast = await getAST(file);
-    })
-  );
+	await Promise.all(
+		sdkFiles.map(async file => {
+			file.ast = await getAST(file);
+		})
+	);
 
-  methods = await extractClientBasedSDKdata(methods, sdkFiles).then(
-    result => result
-  );
-  const groupedMethods = groupers.gcp(methods);
-  methods = filters.gcp(groupedMethods);
+	methods = await extractClientBasedSDKdata(methods, sdkFiles).then(
+		result => result
+	);
+	const groupedMethods = groupers.gcp(methods);
+	methods = filters.gcp(groupedMethods);
 
-  const classData = {
-    functions: methods,
-    serviceName
-  };
+	const classData = {
+		functions: methods,
+		serviceName,
+	};
 
-  const output = await clientBasedTransform(dummyAst, classData);
-  let filePath;
-  const dir = getDir(serviceName);
-  if (!fs.existsSync(process.cwd() + "/generatedClasses/googleCloud/" + dir)) {
-    fs.mkdirSync(process.cwd() + "/generatedClasses/googleCloud/" + dir);
-  }
-  if (/^[A-Z]*$/.test(serviceName)) {
-    filePath =
-      process.cwd() +
-      "/generatedClasses/googleCloud/" +
-      dir +
-      "/gcp-" +
-      serviceName +
-      ".js";
-  } else {
-    filePath =
-      process.cwd() +
-      "/generatedClasses/googleCloud/" +
-      dir +
-      "/gcp-" +
-      serviceName.charAt(0).toLowerCase() +
-      serviceName.slice(1) +
-      ".js";
-  }
-  printFile(filePath, output);
+	const output = await clientBasedTransform(dummyAst, classData);
+	let filePath;
+	const dir = getDir(serviceName);
+	if (
+		!fs.existsSync(process.cwd() + '/generatedClasses/googleCloud/' + dir)
+	) {
+		fs.mkdirSync(process.cwd() + '/generatedClasses/googleCloud/' + dir);
+	}
+	if (/^[A-Z]*$/.test(serviceName)) {
+		filePath =
+			process.cwd() +
+			'/generatedClasses/googleCloud/' +
+			dir +
+			'/gcp-' +
+			serviceName +
+			'.js';
+	} else {
+		filePath =
+			process.cwd() +
+			'/generatedClasses/googleCloud/' +
+			dir +
+			'/gcp-' +
+			serviceName.charAt(0).toLowerCase() +
+			serviceName.slice(1) +
+			'.js';
+	}
+	printFile(filePath, output);
 }
 
 export async function generateGCPClass(serviceClass, serviceName) {
-  let methods: FunctionData[] = [];
-  const data: any = {};
+	let methods: FunctionData[] = [];
+	const data: any = {};
 
-  Object.keys(serviceClass).map((key, index) => {
-    if (key === "mainClass") {
-      data.mainClass = serviceClass[key];
-    } else if (
-      serviceClass[key].split(" ")[1].length === 2 &&
-      serviceClass[key].split(" ")[1].charAt(0) === "v"
-    ) {
-      methods.push({
-        pkgName: serviceClass[key].split(" ")[0],
-        version: serviceClass[key].split(" ")[1],
-        fileName: serviceClass[key].split(" ")[2],
-        functionName: key,
-        SDKFunctionName: serviceClass[key].split(" ")[3],
-        params: [],
-        returnType: null,
-        returnTypeName: null,
-        client: null
-      });
-    } else {
-      methods.push({
-        pkgName: serviceClass[key].split(" ")[0],
-        version: null,
-        fileName: serviceClass[key].split(" ")[1],
-        functionName: key,
-        SDKFunctionName: serviceClass[key].split(" ")[2],
-        params: [],
-        returnType: null,
-        returnTypeName: null,
-        client: null
-      });
-    }
-  });
+	Object.keys(serviceClass).map((key, index) => {
+		if (key === 'mainClass') {
+			data.mainClass = serviceClass[key];
+		} else if (
+			serviceClass[key].split(' ')[1].length === 2 &&
+			serviceClass[key].split(' ')[1].charAt(0) === 'v'
+		) {
+			methods.push({
+				pkgName: serviceClass[key].split(' ')[0],
+				version: serviceClass[key].split(' ')[1],
+				fileName: serviceClass[key].split(' ')[2],
+				functionName: key,
+				SDKFunctionName: serviceClass[key].split(' ')[3],
+				params: [],
+				returnType: null,
+				returnTypeName: null,
+				client: null,
+			});
+		} else {
+			methods.push({
+				pkgName: serviceClass[key].split(' ')[0],
+				version: null,
+				fileName: serviceClass[key].split(' ')[1],
+				functionName: key,
+				SDKFunctionName: serviceClass[key].split(' ')[2],
+				params: [],
+				returnType: null,
+				returnTypeName: null,
+				client: null,
+			});
+		}
+	});
 
-  if (methods[0].version) {
-    generateClientBasedCode(methods, serviceName);
-  } else {
-    generateClassBasedCode(methods, data, serviceName);
-  }
+	if (methods[0].version) {
+		generateClientBasedCode(methods, serviceName);
+	} else {
+		generateClassBasedCode(methods, data, serviceName);
+	}
 }

--- a/generator/generators/lib/aws/awsHelper.ts
+++ b/generator/generators/lib/aws/awsHelper.ts
@@ -1,32 +1,32 @@
 export function groupAWSMethods(methods): any {
-  const methodArr = Object.values(
-    methods.reduce((result, { functionName, SDKFunctionName, params }) => {
-      // Create new group
-      if (!result[functionName])
-        result[functionName] = {
-          functionName,
-          array: []
-        };
-      // Append to group
-      result[functionName].array.push({
-        functionName,
-        SDKFunctionName,
-        params
-      });
-      return result;
-    }, {})
-  );
+	const methodArr = Object.values(
+		methods.reduce((result, { functionName, SDKFunctionName, params }) => {
+			// Create new group
+			if (!result[functionName])
+				result[functionName] = {
+					functionName,
+					array: [],
+				};
+			// Append to group
+			result[functionName].array.push({
+				functionName,
+				SDKFunctionName,
+				params,
+			});
+			return result;
+		}, {})
+	);
 
-  return methodArr;
+	return methodArr;
 }
 
 export function filterAWSMethods(groupedMethods): any {
-  let methods = [];
-  groupedMethods.map(group => {
-    group.array.sort(function(a, b) {
-      return a.params.length - b.params.length;
-    });
-    methods.push(group.array.slice(-1)[0]);
-  });
-  return methods;
+	let methods = [];
+	groupedMethods.map(group => {
+		group.array.sort(function(a, b) {
+			return a.params.length - b.params.length;
+		});
+		methods.push(group.array.slice(-1)[0]);
+	});
+	return methods;
 }

--- a/generator/generators/lib/azure/azureHelper.ts
+++ b/generator/generators/lib/azure/azureHelper.ts
@@ -1,60 +1,60 @@
 export function groupAzureMethods(methods): any {
-  const methodArr = Object.values(
-    methods.reduce(
-      (
-        result,
-        {
-          functionName,
-          SDKFunctionName,
-          params,
-          pkgName,
-          fileName,
-          client,
-          returnType
-        }
-      ) => {
-        // Create new group
-        if (!result[functionName])
-          result[functionName] = {
-            functionName,
-            array: []
-          };
-        // Append to group
-        result[functionName].array.push({
-          functionName,
-          SDKFunctionName,
-          params,
-          pkgName,
-          fileName,
-          client,
-          returnType
-        });
-        return result;
-      },
-      {}
-    )
-  );
+	const methodArr = Object.values(
+		methods.reduce(
+			(
+				result,
+				{
+					functionName,
+					SDKFunctionName,
+					params,
+					pkgName,
+					fileName,
+					client,
+					returnType,
+				}
+			) => {
+				// Create new group
+				if (!result[functionName])
+					result[functionName] = {
+						functionName,
+						array: [],
+					};
+				// Append to group
+				result[functionName].array.push({
+					functionName,
+					SDKFunctionName,
+					params,
+					pkgName,
+					fileName,
+					client,
+					returnType,
+				});
+				return result;
+			},
+			{}
+		)
+	);
 
-  return methodArr;
+	return methodArr;
 }
 
 export function filterAzureMethods(groupedMethods): any {
-  let methods = [];
-  groupedMethods.map(group => {
-    if (group.array.length === 1) {
-      methods.push(group.array[0]);
-    } else {
-      let methodPushed = false;
-      group.array.map(method => {
-        if (!method.params.find(param => param.name === "callback")) {
-          methods.push(method);
-          methodPushed = true;
-        }
-      });
-      if (!methodPushed) {
-        methods.push(group.array[0]);
-      }
-    }
-  });
-  return methods;
+	let methods = [];
+	groupedMethods.map(group => {
+		if (group.array.length === 1) {
+			methods.push(group.array[0]);
+		} else {
+			let methodPushed = false;
+			group.array.map(method => {
+				if (!method.params.find(param => param.name === 'callback')) {
+					methods.push(method);
+					methodPushed = true;
+				}
+			});
+			if (!methodPushed) {
+				methods.push(group.array[0]);
+			}
+		}
+	});
+	return methods;
 }

--- a/generator/generators/lib/googleCloud/gcpHelper.ts
+++ b/generator/generators/lib/googleCloud/gcpHelper.ts
@@ -1,64 +1,64 @@
 export function groupGCPMethods(methods): any {
-  const methodArr = Object.values(
-    methods.reduce(
-      (
-        result,
-        {
-          functionName,
-          SDKFunctionName,
-          params,
-          pkgName,
-          fileName,
-          client,
-          returnType,
-          returnTypeName,
-          classConstructorData
-        }
-      ) => {
-        // Create new group
-        if (!result[functionName])
-          result[functionName] = {
-            functionName,
-            array: []
-          };
-        // Append to group
-        result[functionName].array.push({
-          functionName,
-          SDKFunctionName,
-          params,
-          pkgName,
-          fileName,
-          client,
-          returnType,
-          returnTypeName,
-          classConstructorData
-        });
-        return result;
-      },
-      {}
-    )
-  );
+	const methodArr = Object.values(
+		methods.reduce(
+			(
+				result,
+				{
+					functionName,
+					SDKFunctionName,
+					params,
+					pkgName,
+					fileName,
+					client,
+					returnType,
+					returnTypeName,
+					classConstructorData,
+				}
+			) => {
+				// Create new group
+				if (!result[functionName])
+					result[functionName] = {
+						functionName,
+						array: [],
+					};
+				// Append to group
+				result[functionName].array.push({
+					functionName,
+					SDKFunctionName,
+					params,
+					pkgName,
+					fileName,
+					client,
+					returnType,
+					returnTypeName,
+					classConstructorData,
+				});
+				return result;
+			},
+			{}
+		)
+	);
 
-  return methodArr;
+	return methodArr;
 }
 
 export function filterGCPMethods(groupedMethods): any {
-  let methods = [];
-  groupedMethods.map(group => {
-    if (group.array.length === 1) {
-      methods.push(group.array[0]);
-    } else {
-      let methodPushed = false;
-      group.array.map(method => {
-        if (!method.params.find(param => param.name === "callback")) {
-          methods.push(method);
-          methodPushed = true;
-        }
-      });
-      if (!methodPushed) {
-        methods.push(group.array[0]);
-      }
-    }
-  });
-  return methods;
+	let methods = [];
+	groupedMethods.map(group => {
+		if (group.array.length === 1) {
+			methods.push(group.array[0]);
+		} else {
+			let methodPushed = false;
+			group.array.map(method => {
+				if (!method.params.find(param => param.name === 'callback')) {
+					methods.push(method);
+					methodPushed = true;
+				}
+			});
+			if (!methodPushed) {
+				methods.push(group.array[0]);
+			}
+		}
+	});
+	return methods;
 }

--- a/generator/generators/lib/helper.ts
+++ b/generator/generators/lib/helper.ts
@@ -1,48 +1,48 @@
-import * as fs from "fs";
+import * as fs from 'fs';
 
-import { groupAWSMethods } from "../lib/aws/awsHelper";
-import { filterAWSMethods } from "../lib/aws/awsHelper";
-import { groupAzureMethods } from "../lib/azure/azureHelper";
-import { filterAzureMethods } from "../lib/azure/azureHelper";
-import { groupGCPMethods } from "../lib/googleCloud/gcpHelper";
-import { filterGCPMethods } from "../lib/googleCloud/gcpHelper";
+import { groupAWSMethods } from '../lib/aws/awsHelper';
+import { filterAWSMethods } from '../lib/aws/awsHelper';
+import { groupAzureMethods } from '../lib/azure/azureHelper';
+import { filterAzureMethods } from '../lib/azure/azureHelper';
+import { groupGCPMethods } from '../lib/googleCloud/gcpHelper';
+import { filterGCPMethods } from '../lib/googleCloud/gcpHelper';
 
 const dirMap = {
-  appServices: ["PaaS"],
-  compute: ["ComputeInstance", "Kubernetes", "Container"],
-  database: ["NoSqlIndexed", "RDBMS", "NoSql"],
-  management: ["Monitoring", "KeyManagement", "NotificationService"],
-  network: ["DNS", "LoadBalancer"],
-  security: ["IAM"],
-  storage: ["StorageBucket", "BlockStorage", "ArchivalStorage"],
-  artificialinteligence: ["Translation"]
+	appServices: ['PaaS'],
+	compute: ['ComputeInstance', 'Kubernetes', 'Container'],
+	database: ['NoSqlIndexed', 'RDBMS', 'NoSql'],
+	management: ['Monitoring', 'KeyManagement', 'NotificationService'],
+	network: ['DNS', 'LoadBalancer'],
+	security: ['IAM'],
+	storage: ['StorageBucket', 'BlockStorage', 'ArchivalStorage'],
+	artificialinteligence: ['Translation'],
 };
 
 export function printFile(fileName, data) {
-  fs.writeFile(fileName, data, function(err) {
-    if (err) throw err;
-  });
+	fs.writeFile(fileName, data, function(err) {
+		if (err) throw err;
+	});
 }
 
 const groupers = {
-  aws: groupAWSMethods,
-  gcp: groupGCPMethods,
-  azure: groupAzureMethods
+	aws: groupAWSMethods,
+	gcp: groupGCPMethods,
+	azure: groupAzureMethods,
 };
 
 const filters = {
-  aws: filterAWSMethods,
-  gcp: filterGCPMethods,
-  azure: filterAzureMethods
+	aws: filterAWSMethods,
+	gcp: filterGCPMethods,
+	azure: filterAzureMethods,
 };
 
 const getDir = (service: string): string => {
-  for (let dir in dirMap) {
-    if (dirMap[dir].includes(service)) {
-      return dir;
-    }
-  }
-  throw new Error("Not a valid service: " + service);
+	for (let dir in dirMap) {
+		if (dirMap[dir].includes(service)) {
+			return dir;
+		}
+	}
+	throw new Error('Not a valid service: ' + service);
 };
 
-export { filters, getDir,groupers };
+export { filters, getDir, groupers };

--- a/generator/main.ts
+++ b/generator/main.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 
+import { generateAliyunClass } from './generators/aliyun/generator';
 import { generateAWSClass } from './generators/aws/generator';
 import { generateAzureClass } from './generators/azure/generator';
 import { generateDOClass } from './generators/do/generator';
@@ -18,6 +19,8 @@ try {
 				generateGCPClass(services[service][provider], service);
 			} else if (provider == 'DO') {
 				generateDOClass(services[service][provider], service);
+			} else if (provider === 'Ali') {
+				generateAliyunClass(services[service][provider], service);
 			}
 		});
 	});

--- a/generator/main.ts
+++ b/generator/main.ts
@@ -1,26 +1,26 @@
-import * as fs from "fs";
-import * as yaml from "js-yaml";
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
 
-import { generateAWSClass } from "./generators/aws/generator";
-import { generateAzureClass } from "./generators/azure/generator";
-import { generateDOClass } from "./generators/do/generator";
-import { generateGCPClass } from "./generators/googleCloud/generator";
+import { generateAWSClass } from './generators/aws/generator';
+import { generateAzureClass } from './generators/azure/generator';
+import { generateDOClass } from './generators/do/generator';
+import { generateGCPClass } from './generators/googleCloud/generator';
 
 try {
-  const services = yaml.safeLoad(fs.readFileSync("node-cloud.yml", "utf8"));
-  Object.keys(services).map((service, index) => {
-    Object.keys(services[service]).map((provider, index1) => {
-      if (provider === "Azure") {
-        generateAzureClass(services[service][provider], service);
-      } else if (provider === "AWS") {
-        generateAWSClass(services[service][provider], service);
-      } else if (provider === "GCP") {
-        generateGCPClass(services[service][provider], service);
-      } else if (provider == "DO") {
-        generateDOClass(services[service][provider], service);
-      }
-    });
-  });
+	const services = yaml.safeLoad(fs.readFileSync('node-cloud.yml', 'utf8'));
+	Object.keys(services).map((service, index) => {
+		Object.keys(services[service]).map((provider, index1) => {
+			if (provider === 'Azure') {
+				generateAzureClass(services[service][provider], service);
+			} else if (provider === 'AWS') {
+				generateAWSClass(services[service][provider], service);
+			} else if (provider === 'GCP') {
+				generateGCPClass(services[service][provider], service);
+			} else if (provider == 'DO') {
+				generateDOClass(services[service][provider], service);
+			}
+		});
+	});
 } catch (error) {
-  console.error("Error : ", error);
+	console.error('Error : ', error);
 }

--- a/generator/node-cloud.yml
+++ b/generator/node-cloud.yml
@@ -43,6 +43,14 @@ StorageBucket:
     list: storage storage.d.ts getBuckets
     upload: storage bucket.d.ts upload
     makePublic: storage file.d.ts makePublic
+  Ali:
+    setRegion: oss index.d.ts setRegion
+    create: oss index.d.ts create
+    listBuckets: oss index.d.ts listBuckets
+    delete: oss index.d.ts delete
+    describeBucket: oss index.d.ts describeBucket
+    listBucketObjects: oss index.d.ts listBucketObjects
+    uploadLocalObject: oss index.d.ts uploadLocalObject
 
 PaaS:
   AWS:

--- a/generator/package.json
+++ b/generator/package.json
@@ -31,6 +31,7 @@
 		"@google-cloud/pubsub": "^2.1.0",
 		"@google-cloud/storage": "^5.1.1",
 		"@google-cloud/translate": "^6.0.0",
+		"aliyun-v2-typescript-sdk": "^0.1.1",
 		"aws-sdk": "^2.686.0",
 		"config": "^1.26.1",
 		"do-wrapper": "^4.5.1",

--- a/generator/package.json
+++ b/generator/package.json
@@ -1,42 +1,42 @@
 {
-  "name": "class-generator",
-  "version": "1.0.0",
-  "main": "main.js",
-  "author": "Scorelab",
-  "description": "NodeCloud code generation tool",
-  "license": "Apache-2.0",
-  "keywords": [
-    "nodecloud",
-    "code-generation"
-  ],
-  "scripts": {
-    "test": "cross-env TS_NODE_FILES=true mocha --exit --require ts-node/register --colors test/**/*.ts",
-    "tool": "tsc main && node main",
-    "lint": "eslint .",
+	"name": "class-generator",
+	"version": "1.0.0",
+	"main": "main.js",
+	"author": "Scorelab",
+	"description": "NodeCloud code generation tool",
+	"license": "Apache-2.0",
+	"keywords": [
+		"nodecloud",
+		"code-generation"
+	],
+	"scripts": {
+		"test": "cross-env TS_NODE_FILES=true mocha --exit --require ts-node/register --colors test/**/*.ts",
+		"tool": "tsc main && node main",
+		"lint": "eslint .",
 		"lint-fix": "eslint --fix ."
-  },
-  "dependencies": {
-    "@azure/arm-appservice": "^6.0.0",
-    "@azure/arm-compute": "^14.0.0",
-    "@azure/arm-containerservice": "^11.0.0",
-    "@azure/arm-cosmosdb": "^8.0.0",
-    "@azure/arm-keyvault": "^1.2.1",
-    "@azure/arm-monitor": "^6.0.0",
-    "@azure/arm-sql": "^7.0.0",
-    "@azure/arm-storage": "^15.0.0",
-    "@google-cloud/compute": "^2.0.0",
-    "@google-cloud/container": "^2.1.0",
-    "@google-cloud/dns": "^2.0.1",
-    "@google-cloud/monitoring": "^2.0.0",
-    "@google-cloud/pubsub": "^2.1.0",
-    "@google-cloud/storage": "^5.1.1",
-    "@google-cloud/translate": "^6.0.0",
-    "aws-sdk": "^2.686.0",
-    "config": "^1.26.1",
-    "do-wrapper": "^4.5.1",
-    "js-yaml": "^3.14.0",
-    "key-mirror": "^1.0.1",
-    "lodash": "^4.17.19",
-    "typescript": "^3.9.3"
-  }
+	},
+	"dependencies": {
+		"@azure/arm-appservice": "^6.0.0",
+		"@azure/arm-compute": "^14.0.0",
+		"@azure/arm-containerservice": "^11.0.0",
+		"@azure/arm-cosmosdb": "^8.0.0",
+		"@azure/arm-keyvault": "^1.2.1",
+		"@azure/arm-monitor": "^6.0.0",
+		"@azure/arm-sql": "^7.0.0",
+		"@azure/arm-storage": "^15.0.0",
+		"@google-cloud/compute": "^2.0.0",
+		"@google-cloud/container": "^2.1.0",
+		"@google-cloud/dns": "^2.0.1",
+		"@google-cloud/monitoring": "^2.0.0",
+		"@google-cloud/pubsub": "^2.1.0",
+		"@google-cloud/storage": "^5.1.1",
+		"@google-cloud/translate": "^6.0.0",
+		"aws-sdk": "^2.686.0",
+		"config": "^1.26.1",
+		"do-wrapper": "^4.5.1",
+		"js-yaml": "^3.14.0",
+		"key-mirror": "^1.0.1",
+		"lodash": "^4.17.19",
+		"typescript": "^3.9.3"
+	}
 }

--- a/generator/parsers/aliyun/parser.js
+++ b/generator/parsers/aliyun/parser.js
@@ -1,0 +1,127 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+exports.__esModule = true;
+exports.extractSDKData = exports.getAST = void 0;
+var fs = require("fs");
+var path = require("path");
+var typescript_1 = require("typescript");
+exports.getAST = function (sdkFilePath) {
+    return new Promise(function (resolve, reject) { return __awaiter(void 0, void 0, void 0, function () {
+        var _a, module, rootFile, service, file, ast, cloned_1, error_1;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    _a = sdkFilePath.split(' '), module = _a[0], rootFile = _a[1], service = _a[2];
+                    _b.label = 1;
+                case 1:
+                    _b.trys.push([1, 3, , 4]);
+                    file = path.join(__dirname, '../../../node_modules/aliyun-v2-typescript-sdk/dist/modules/', module.toLowerCase(), rootFile);
+                    ast = typescript_1.createSourceFile(file, fs.readFileSync(file).toString(), typescript_1.ScriptTarget.Latest, true);
+                    cloned_1 = null;
+                    return [4 /*yield*/, ast.forEachChild(function (child) {
+                            if (typescript_1.SyntaxKind[child.kind] === 'ClassDeclaration') {
+                                cloned_1 = Object.assign({}, child);
+                            }
+                        })];
+                case 2:
+                    _b.sent();
+                    if (!cloned_1) {
+                        reject(new Error('Class not found!'));
+                    }
+                    else {
+                        resolve(cloned_1);
+                    }
+                    return [3 /*break*/, 4];
+                case 3:
+                    error_1 = _b.sent();
+                    if (error_1.code === 'ENOENT') {
+                        reject(new Error('File not found!'));
+                    }
+                    else {
+                        reject(error_1);
+                    }
+                    return [3 /*break*/, 4];
+                case 4: return [2 /*return*/];
+            }
+        });
+    }); });
+};
+exports.extractSDKData = function (sdkClassAst, serviceClass) {
+    var methods = [];
+    var functions = [];
+    Object.keys(serviceClass).forEach(function (key) {
+        functions.push(serviceClass[key].split(' ')[2]);
+    });
+    sdkClassAst.members.forEach(function (method) {
+        if (method.name && functions.includes(method.name.text)) {
+            var name_1;
+            Object.keys(serviceClass).forEach(function (key) {
+                if (serviceClass[key].split(' ')[2] === method.name.text) {
+                    name_1 = key;
+                }
+            });
+            var parameters_1 = [];
+            method.parameters.forEach(function (param) {
+                if (param.name.text !== 'callback') {
+                    var parameter = {
+                        name: param.name.text,
+                        optional: param.questionToken ? true : false,
+                        type: typescript_1.SyntaxKind[param.type.kind],
+                        typeName: null
+                    };
+                    if (parameter.type === 'TypeReference' &&
+                        param.type.typeName) {
+                        parameter.typeName = param.type.typeName.text;
+                    }
+                    parameters_1.push(parameter);
+                }
+            });
+            methods.push({
+                functionName: name_1.toString(),
+                SDKFunctionName: method.name.text.toString(),
+                params: parameters_1
+            });
+        }
+    });
+    var classData = {
+        className: sdkClassAst.name.text,
+        functions: methods,
+        serviceName: null
+    };
+    return classData;
+};

--- a/generator/parsers/aliyun/parser.ts
+++ b/generator/parsers/aliyun/parser.ts
@@ -42,3 +42,76 @@ export const getAST = (sdkFilePath: string) => {
 		}
 	});
 };
+
+export function extractSDKData(sdkClassAst, serviceClass) {
+	let methods: FunctionData[] = [];
+	const functions = [];
+
+	Object.keys(serviceClass).map((key, index) => {
+		functions.push(serviceClass[key].split(' ')[1]);
+	});
+
+	sdkClassAst.members.map(method => {
+		if (method.name && functions.includes(method.name.text)) {
+			let name;
+			Object.keys(serviceClass).map((key, index) => {
+				if (serviceClass[key].split(' ')[1] === method.name.text) {
+					name = key;
+				}
+			});
+
+			const parameters = [];
+			method.parameters.map(param => {
+				if (param.name.text !== 'callback') {
+					const parameter = {
+						name: param.name.text,
+						optional: param.questionToken ? true : false,
+						type: SyntaxKind[param.type.kind],
+						typeName: null,
+					};
+
+					if (
+						parameter.type === 'TypeReference' &&
+						param.type.typeName
+					) {
+						parameter.typeName = param.type.typeName.text;
+					}
+
+					parameters.push(parameter);
+				}
+			});
+
+			methods.push({
+				functionName: name.toString(),
+				SDKFunctionName: method.name.text.toString(),
+				params: parameters,
+			});
+		}
+	});
+
+	const classData: ClassData = {
+		className: sdkClassAst.name.text,
+		functions: methods,
+		serviceName: null,
+	};
+
+	return classData;
+}
+
+export interface ClassData {
+	className: string;
+	functions: FunctionData[];
+	serviceName: string;
+}
+
+interface FunctionData {
+	functionName: string;
+	SDKFunctionName: string;
+	params: param[];
+}
+
+interface param {
+	name: string;
+	type: string;
+	typeName: string;
+}

--- a/generator/parsers/aliyun/parser.ts
+++ b/generator/parsers/aliyun/parser.ts
@@ -43,25 +43,25 @@ export const getAST = (sdkFilePath: string) => {
 	});
 };
 
-export function extractSDKData(sdkClassAst, serviceClass) {
-	let methods: FunctionData[] = [];
+export const extractSDKData = (sdkClassAst, serviceClass): ClassData => {
+	const methods: FunctionData[] = [];
 	const functions = [];
 
-	Object.keys(serviceClass).map((key, index) => {
-		functions.push(serviceClass[key].split(' ')[1]);
+	Object.keys(serviceClass).forEach((key: string) => {
+		functions.push(serviceClass[key].split(' ')[2]);
 	});
 
-	sdkClassAst.members.map(method => {
+	sdkClassAst.members.forEach(method => {
 		if (method.name && functions.includes(method.name.text)) {
 			let name;
-			Object.keys(serviceClass).map((key, index) => {
-				if (serviceClass[key].split(' ')[1] === method.name.text) {
+			Object.keys(serviceClass).forEach((key: string) => {
+				if (serviceClass[key].split(' ')[2] === method.name.text) {
 					name = key;
 				}
 			});
 
 			const parameters = [];
-			method.parameters.map(param => {
+			method.parameters.forEach(param => {
 				if (param.name.text !== 'callback') {
 					const parameter = {
 						name: param.name.text,
@@ -96,7 +96,7 @@ export function extractSDKData(sdkClassAst, serviceClass) {
 	};
 
 	return classData;
-}
+};
 
 export interface ClassData {
 	className: string;

--- a/generator/parsers/aliyun/parser.ts
+++ b/generator/parsers/aliyun/parser.ts
@@ -1,0 +1,44 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { createSourceFile, ScriptTarget, SyntaxKind } from 'typescript';
+
+export const getAST = (sdkFilePath: string) => {
+	return new Promise(async (resolve, reject) => {
+		const [module, rootFile, service] = sdkFilePath.split(' ');
+		try {
+			const file = path.join(
+				__dirname,
+				'../../../node_modules/aliyun-v2-typescript-sdk/dist/modules/',
+				module.toLowerCase(),
+				rootFile
+			);
+
+			const ast = createSourceFile(
+				file,
+				fs.readFileSync(file).toString(),
+				ScriptTarget.Latest,
+				true
+			);
+
+			let cloned = null;
+
+			await ast.forEachChild(child => {
+				if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+					cloned = Object.assign({}, child);
+				}
+			});
+
+			if (!cloned) {
+				reject(new Error('Class not found!'));
+			} else {
+				resolve(cloned);
+			}
+		} catch (error) {
+			if (error.code === 'ENOENT') {
+				reject(new Error('File not found!'));
+			} else {
+				reject(error);
+			}
+		}
+	});
+};

--- a/generator/parsers/aws/parser.ts
+++ b/generator/parsers/aws/parser.ts
@@ -1,39 +1,40 @@
-import * as fs from "fs";
-import * as path from "path";
-import { createSourceFile, ScriptTarget, SyntaxKind } from "typescript";
+import * as fs from 'fs';
+import * as path from 'path';
+import { createSourceFile, ScriptTarget, SyntaxKind } from 'typescript';
 
 export function getAST(sdkFileName) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const file = path.join(
-        __dirname,
-        "../../../node_modules/aws-sdk/clients/" + sdkFileName.toLowerCase()
-      );
-      const ast = createSourceFile(
-        file,
-        fs.readFileSync(file).toString(),
-        ScriptTarget.Latest,
-        true
-      );
+	return new Promise(async (resolve, reject) => {
+		try {
+			const file = path.join(
+				__dirname,
+				'../../../node_modules/aws-sdk/clients/' +
+					sdkFileName.toLowerCase()
+			);
+			const ast = createSourceFile(
+				file,
+				fs.readFileSync(file).toString(),
+				ScriptTarget.Latest,
+				true
+			);
 
-      let cloned = null;
-      await ast.forEachChild(child => {
-        if (SyntaxKind[child.kind] === "ClassDeclaration") {
-          cloned = Object.assign({}, child);
-        }
-      });
+			let cloned = null;
+			await ast.forEachChild(child => {
+				if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+					cloned = Object.assign({}, child);
+				}
+			});
 
-      if (!cloned) {
-        reject(new Error("Class not found!"));
-      } else {
-        resolve(cloned);
-      }
-    } catch (error) {
-      if (error.code === "ENOENT") {
-        reject(new Error("File not found!"));
-      } else {
-        reject(error);
-      }
-    }
-  });
+			if (!cloned) {
+				reject(new Error('Class not found!'));
+			} else {
+				resolve(cloned);
+			}
+		} catch (error) {
+			if (error.code === 'ENOENT') {
+				reject(new Error('File not found!'));
+			} else {
+				reject(error);
+			}
+		}
+	});
 }

--- a/generator/parsers/azure/parser.ts
+++ b/generator/parsers/azure/parser.ts
@@ -1,39 +1,39 @@
-import * as fs from "fs";
-import * as path from "path";
-import { createSourceFile, ScriptTarget, SyntaxKind } from "typescript";
+import * as fs from 'fs';
+import * as path from 'path';
+import { createSourceFile, ScriptTarget, SyntaxKind } from 'typescript';
 
 export function getAST(sdkFileInfo) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const file = path.join(
-        __dirname,
-        `../../../node_modules/@azure/${sdkFileInfo.pkgName}/esm/operations/${sdkFileInfo.fileName}`
-      );
-      const ast = createSourceFile(
-        file,
-        fs.readFileSync(file).toString(),
-        ScriptTarget.Latest,
-        true
-      );
+	return new Promise(async (resolve, reject) => {
+		try {
+			const file = path.join(
+				__dirname,
+				`../../../node_modules/@azure/${sdkFileInfo.pkgName}/esm/operations/${sdkFileInfo.fileName}`
+			);
+			const ast = createSourceFile(
+				file,
+				fs.readFileSync(file).toString(),
+				ScriptTarget.Latest,
+				true
+			);
 
-      let cloned = null;
-      await ast.forEachChild(child => {
-        if (SyntaxKind[child.kind] === "ClassDeclaration") {
-          cloned = Object.assign({}, child);
-        }
-      });
+			let cloned = null;
+			await ast.forEachChild(child => {
+				if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+					cloned = Object.assign({}, child);
+				}
+			});
 
-      if (!cloned) {
-        reject(new Error("Class not found!"));
-      } else {
-        resolve(cloned);
-      }
-    } catch (error) {
-      if (error.code === "ENOENT") {
-        reject(new Error("File not found!"));
-      } else {
-        reject(error);
-      }
-    }
-  });
+			if (!cloned) {
+				reject(new Error('Class not found!'));
+			} else {
+				resolve(cloned);
+			}
+		} catch (error) {
+			if (error.code === 'ENOENT') {
+				reject(new Error('File not found!'));
+			} else {
+				reject(error);
+			}
+		}
+	});
 }

--- a/generator/parsers/do/parser.ts
+++ b/generator/parsers/do/parser.ts
@@ -1,41 +1,41 @@
-import * as fs from "fs";
-import * as path from "path";
-import { createSourceFile, ScriptTarget, SyntaxKind } from "typescript";
+import * as fs from 'fs';
+import * as path from 'path';
+import { createSourceFile, ScriptTarget, SyntaxKind } from 'typescript';
 
 export function getAST(sdkFileName) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const file = path.join(
-        __dirname,
-        "../../../node_modules/do-wrapper/dist/modules/" +
-          sdkFileName.toLowerCase()
-      );
-      const ast = createSourceFile(
-        file,
-        fs.readFileSync(file).toString(),
-        ScriptTarget.Latest,
-        true
-      );
+	return new Promise(async (resolve, reject) => {
+		try {
+			const file = path.join(
+				__dirname,
+				'../../../node_modules/do-wrapper/dist/modules/' +
+					sdkFileName.toLowerCase()
+			);
+			const ast = createSourceFile(
+				file,
+				fs.readFileSync(file).toString(),
+				ScriptTarget.Latest,
+				true
+			);
 
-      let cloned = null;
+			let cloned = null;
 
-      await ast.forEachChild(child => {
-        if (SyntaxKind[child.kind] === "ClassDeclaration") {
-          cloned = Object.assign({}, child);
-        }
-      });
+			await ast.forEachChild(child => {
+				if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+					cloned = Object.assign({}, child);
+				}
+			});
 
-      if (!cloned) {
-        reject(new Error("Class not found!"));
-      } else {
-        resolve(cloned);
-      }
-    } catch (error) {
-      if (error.code === "ENOENT") {
-        reject(new Error("File not found!"));
-      } else {
-        reject(error);
-      }
-    }
-  });
+			if (!cloned) {
+				reject(new Error('Class not found!'));
+			} else {
+				resolve(cloned);
+			}
+		} catch (error) {
+			if (error.code === 'ENOENT') {
+				reject(new Error('File not found!'));
+			} else {
+				reject(error);
+			}
+		}
+	});
 }

--- a/generator/parsers/googleCloud/parser.ts
+++ b/generator/parsers/googleCloud/parser.ts
@@ -1,55 +1,55 @@
-import * as fs from "fs";
-import * as path from "path";
-import { createSourceFile, ScriptTarget, SyntaxKind } from "typescript";
+import * as fs from 'fs';
+import * as path from 'path';
+import { createSourceFile, ScriptTarget, SyntaxKind } from 'typescript';
 
 export function getAST(sdkFileInfo, multi?: boolean) {
-  let filePath;
-  if (sdkFileInfo.version) {
-    filePath = `../../../node_modules/@google-cloud/${sdkFileInfo.pkgName}/build/src/${sdkFileInfo.version}/${sdkFileInfo.fileName}`;
-  } else {
-    filePath = `../../../node_modules/@google-cloud/${sdkFileInfo.pkgName}/build/src/${sdkFileInfo.fileName}`;
-  }
+	let filePath;
+	if (sdkFileInfo.version) {
+		filePath = `../../../node_modules/@google-cloud/${sdkFileInfo.pkgName}/build/src/${sdkFileInfo.version}/${sdkFileInfo.fileName}`;
+	} else {
+		filePath = `../../../node_modules/@google-cloud/${sdkFileInfo.pkgName}/build/src/${sdkFileInfo.fileName}`;
+	}
 
-  return new Promise(async (resolve, reject) => {
-    try {
-      const file = path.join(__dirname, filePath);
-      const ast = createSourceFile(
-        file,
-        fs.readFileSync(file).toString(),
-        ScriptTarget.Latest,
-        true
-      );
+	return new Promise(async (resolve, reject) => {
+		try {
+			const file = path.join(__dirname, filePath);
+			const ast = createSourceFile(
+				file,
+				fs.readFileSync(file).toString(),
+				ScriptTarget.Latest,
+				true
+			);
 
-      if (multi === true) {
-        let classes = [];
-        ast.forEachChild(child => {
-          if (SyntaxKind[child.kind] === "ClassDeclaration") {
-            let cloned = Object.assign({}, child);
-            classes.push(cloned);
-          }
-        });
-        resolve(classes);
-      } else {
-        let cloned = null;
-        await ast.forEachChild(child => {
-          if (SyntaxKind[child.kind] === "ClassDeclaration") {
-            let cloned = Object.assign({}, child);
-            return resolve(cloned);
-          }
-        });
+			if (multi === true) {
+				let classes = [];
+				ast.forEachChild(child => {
+					if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+						let cloned = Object.assign({}, child);
+						classes.push(cloned);
+					}
+				});
+				resolve(classes);
+			} else {
+				let cloned = null;
+				await ast.forEachChild(child => {
+					if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+						let cloned = Object.assign({}, child);
+						return resolve(cloned);
+					}
+				});
 
-        if (!cloned) {
-          return reject(new Error("Class not found!"));
-        } else {
-          return resolve(cloned);
-        }
-      }
-    } catch (error) {
-      if (error.code === "ENOENT") {
-        reject(new Error("File not found!"));
-      } else {
-        reject(error);
-      }
-    }
-  });
+				if (!cloned) {
+					return reject(new Error('Class not found!'));
+				} else {
+					return resolve(cloned);
+				}
+			}
+		} catch (error) {
+			if (error.code === 'ENOENT') {
+				reject(new Error('File not found!'));
+			} else {
+				reject(error);
+			}
+		}
+	});
 }

--- a/generator/test/generators/aws/dummyData/invalidDataset_1/serviceClass.json
+++ b/generator/test/generators/aws/dummyData/invalidDataset_1/serviceClass.json
@@ -1,11 +1,11 @@
 {
-  "createCollection": "SimpleDB.d.ts createDomain",
-  "deleteCollection": "SimpleDB.d.ts",
-  "listCollections": "SimpleDB.d.ts listDomains",
-  "batchDelete": "SimpleDB.d.ts batchDeleteAttributes",
-  "batchWrite": "SimpleDB.d.ts batchPutAttributes",
-  "query": "SimpleDB.d.ts select",
-  "setAttribute": "SimpleDB.d.ts putAttributes",
-  "deleteAttribute": "SimpleDB.d.ts deleteAttributes",
-  "getAttributes": "SimpleDB.d.ts getAttributes"
+	"createCollection": "SimpleDB.d.ts createDomain",
+	"deleteCollection": "SimpleDB.d.ts",
+	"listCollections": "SimpleDB.d.ts listDomains",
+	"batchDelete": "SimpleDB.d.ts batchDeleteAttributes",
+	"batchWrite": "SimpleDB.d.ts batchPutAttributes",
+	"query": "SimpleDB.d.ts select",
+	"setAttribute": "SimpleDB.d.ts putAttributes",
+	"deleteAttribute": "SimpleDB.d.ts deleteAttributes",
+	"getAttributes": "SimpleDB.d.ts getAttributes"
 }

--- a/generator/test/generators/aws/dummyData/invalidDataset_2/serviceClass.json
+++ b/generator/test/generators/aws/dummyData/invalidDataset_2/serviceClass.json
@@ -1,11 +1,11 @@
 {
-  "createCollection": "SimpleDB.d.ts createDomain",
-  "deleteCollection": "SimpleDB.d.ts deleteDomain",
-  "listCollections": "SimpleDB.d.ts listDomains",
-  "batchDelete": "SimpleDB.d.ts batchDeleteAttributes",
-  "batchWrite": "SimpleDB.d.ts batchPutAttributes",
-  "query": "SimpleDB.d.ts select",
-  "setAttribute": "SimpleDB.d.ts putAttributes",
-  "deleteAttribute": "SimpleDB.d.ts deleteAttributes",
-  "getAttributes": "SimpleDB.d.ts getAttributes"
+	"createCollection": "SimpleDB.d.ts createDomain",
+	"deleteCollection": "SimpleDB.d.ts deleteDomain",
+	"listCollections": "SimpleDB.d.ts listDomains",
+	"batchDelete": "SimpleDB.d.ts batchDeleteAttributes",
+	"batchWrite": "SimpleDB.d.ts batchPutAttributes",
+	"query": "SimpleDB.d.ts select",
+	"setAttribute": "SimpleDB.d.ts putAttributes",
+	"deleteAttribute": "SimpleDB.d.ts deleteAttributes",
+	"getAttributes": "SimpleDB.d.ts getAttributes"
 }

--- a/generator/test/generators/aws/dummyData/validDataset/serviceClass.json
+++ b/generator/test/generators/aws/dummyData/validDataset/serviceClass.json
@@ -1,11 +1,11 @@
 {
-  "createCollection": "SimpleDB.d.ts createDomain",
-  "deleteCollection": "SimpleDB.d.ts deleteDomain",
-  "listCollections": "SimpleDB.d.ts listDomains",
-  "batchDelete": "SimpleDB.d.ts batchDeleteAttributes",
-  "batchWrite": "SimpleDB.d.ts batchPutAttributes",
-  "query": "SimpleDB.d.ts select",
-  "setAttribute": "SimpleDB.d.ts putAttributes",
-  "deleteAttribute": "SimpleDB.d.ts deleteAttributes",
-  "getAttributes": "SimpleDB.d.ts getAttributes"
+	"createCollection": "SimpleDB.d.ts createDomain",
+	"deleteCollection": "SimpleDB.d.ts deleteDomain",
+	"listCollections": "SimpleDB.d.ts listDomains",
+	"batchDelete": "SimpleDB.d.ts batchDeleteAttributes",
+	"batchWrite": "SimpleDB.d.ts batchPutAttributes",
+	"query": "SimpleDB.d.ts select",
+	"setAttribute": "SimpleDB.d.ts putAttributes",
+	"deleteAttribute": "SimpleDB.d.ts deleteAttributes",
+	"getAttributes": "SimpleDB.d.ts getAttributes"
 }

--- a/generator/test/generators/aws/generator.test.ts
+++ b/generator/test/generators/aws/generator.test.ts
@@ -1,86 +1,92 @@
-import { expect } from "chai";
-import { SyntaxKind } from "typescript";
+import { expect } from 'chai';
+import { SyntaxKind } from 'typescript';
 
-import { extractSDKData } from "../../../generators/aws/generator";
-import { readJsonData,readSourceFile } from "../lib/helper";
+import { extractSDKData } from '../../../generators/aws/generator';
+import { readJsonData, readSourceFile } from '../lib/helper';
 
-describe("AWS generator extractSDKData", () => {
-  context("with valid methods and valid AST", () => {
-    it("should return extracted class data", async () => {
-      const sdkFile: any = await readSourceFile("validDataset", "aws");
-      const data: any = await readJsonData(
-        "validDataset",
-        "aws",
-        "serviceClass"
-      );
-      let cloned = null;
-      sdkFile.forEachChild(child => {
-        if (SyntaxKind[child.kind] === "ClassDeclaration") {
-          cloned = Object.assign({}, child);
-        }
-      });
+describe('AWS generator extractSDKData', () => {
+	context('with valid methods and valid AST', () => {
+		it('should return extracted class data', async () => {
+			const sdkFile: any = await readSourceFile('validDataset', 'aws');
+			const data: any = await readJsonData(
+				'validDataset',
+				'aws',
+				'serviceClass'
+			);
+			let cloned = null;
+			sdkFile.forEachChild(child => {
+				if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+					cloned = Object.assign({}, child);
+				}
+			});
 
-      if (cloned) {
-        const result = extractSDKData(cloned, data);
-        expect(result).to.be.an("object");
-        expect(result.functions).to.be.an("array");
-        expect(result.className).to.be.string;
-      } else {
-        console.error("Error in cloning class");
-      }
-    });
-  });
+			if (cloned) {
+				const result = extractSDKData(cloned, data);
+				expect(result).to.be.an('object');
+				expect(result.functions).to.be.an('array');
+				expect(result.className).to.be.string;
+			} else {
+				console.error('Error in cloning class');
+			}
+		});
+	});
 
-  context("with invalid method data:missing method name", () => {
-    it("should drop invalid method", async () => {
-      const sdkFile: any = await readSourceFile("invalidDataset_1", "aws");
-      const data: any = await readJsonData(
-        "invalidDataset_1",
-        "aws",
-        "serviceClass"
-      );
-      let cloned = null;
-      sdkFile.forEachChild(child => {
-        if (SyntaxKind[child.kind] === "ClassDeclaration") {
-          cloned = Object.assign({}, child);
-        }
-      });
+	context('with invalid method data:missing method name', () => {
+		it('should drop invalid method', async () => {
+			const sdkFile: any = await readSourceFile(
+				'invalidDataset_1',
+				'aws'
+			);
+			const data: any = await readJsonData(
+				'invalidDataset_1',
+				'aws',
+				'serviceClass'
+			);
+			let cloned = null;
+			sdkFile.forEachChild(child => {
+				if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+					cloned = Object.assign({}, child);
+				}
+			});
 
-      if (cloned) {
-        expect(
-          extractSDKData(cloned, data).functions.length <
-            Object.keys(data).length
-        ).to.be.true;
-      } else {
-        console.error("Error in cloning class");
-      }
-    });
-  });
+			if (cloned) {
+				expect(
+					extractSDKData(cloned, data).functions.length <
+						Object.keys(data).length
+				).to.be.true;
+			} else {
+				console.error('Error in cloning class');
+			}
+		});
+	});
 
-  context("AST with no functions", () => {
-    it("should return empty array of methods", async () => {
-      const sdkFile: any = await readSourceFile("invalidDataset_2", "aws");
-      const data: any = await readJsonData(
-        "invalidDataset_2",
-        "aws",
-        "serviceClass"
-      );
-      let cloned = null;
-      sdkFile.forEachChild(child => {
-        if (SyntaxKind[child.kind] === "ClassDeclaration") {
-          cloned = Object.assign({}, child);
-        }
-      });
+	context('AST with no functions', () => {
+		it('should return empty array of methods', async () => {
+			const sdkFile: any = await readSourceFile(
+				'invalidDataset_2',
+				'aws'
+			);
+			const data: any = await readJsonData(
+				'invalidDataset_2',
+				'aws',
+				'serviceClass'
+			);
+			let cloned = null;
+			sdkFile.forEachChild(child => {
+				if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+					cloned = Object.assign({}, child);
+				}
+			});
 
-      if (cloned) {
-        const result = extractSDKData(cloned, data);
-        expect(result).to.be.an("object");
-        expect(result.functions).to.be.an("array");
-        expect(result.className).to.be.string;
-        expect(result.functions.length).to.eql(0);
-      } else {
-        console.error("Error in cloning class");
-      }
-    });
-  });
+			if (cloned) {
+				const result = extractSDKData(cloned, data);
+				expect(result).to.be.an('object');
+				expect(result.functions).to.be.an('array');
+				expect(result.className).to.be.string;
+				expect(result.functions.length).to.eql(0);
+			} else {
+				console.error('Error in cloning class');
+			}
+		});
+	});
 });

--- a/generator/test/generators/azure/dummyData/invalidDataset_1/files.json
+++ b/generator/test/generators/azure/dummyData/invalidDataset_1/files.json
@@ -1,15 +1,15 @@
 [
-  {
-    "fileName": "managedClusters.d.ts",
-    "pkgName": "arm-containerservice",
-    "ast": null,
-    "client": null,
-    "sdkFunctionNames": [
-      "createOrUpdate",
-      "deleteMethod",
-      "updateTags",
-      "listByResourceGroup",
-      "list"
-    ]
-  }
+	{
+		"fileName": "managedClusters.d.ts",
+		"pkgName": "arm-containerservice",
+		"ast": null,
+		"client": null,
+		"sdkFunctionNames": [
+			"createOrUpdate",
+			"deleteMethod",
+			"updateTags",
+			"listByResourceGroup",
+			"list"
+		]
+	}
 ]

--- a/generator/test/generators/azure/dummyData/invalidDataset_1/methods.json
+++ b/generator/test/generators/azure/dummyData/invalidDataset_1/methods.json
@@ -1,47 +1,47 @@
 [
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "create",
-    "SDKFunctionName": "createOrUpdate",
-    "params": [],
-    "returnType": null,
-    "client": null
-  },
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "delete",
-    "SDKFunctionName": "deleteMethod",
-    "params": [],
-    "returnType": null,
-    "client": null
-  },
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "updateTags",
-    "SDKFunctionName": "updateTags",
-    "params": [],
-    "returnType": null,
-    "client": null
-  },
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "listByResourceGroup",
-    "SDKFunctionName": "listByResourceGroup",
-    "params": [],
-    "returnType": null,
-    "client": null
-  },
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "listClusters",
-    "SDKFunctionName": "list",
-    "params": [],
-    "returnType": null,
-    "client": null
-  }
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "create",
+		"SDKFunctionName": "createOrUpdate",
+		"params": [],
+		"returnType": null,
+		"client": null
+	},
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "delete",
+		"SDKFunctionName": "deleteMethod",
+		"params": [],
+		"returnType": null,
+		"client": null
+	},
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "updateTags",
+		"SDKFunctionName": "updateTags",
+		"params": [],
+		"returnType": null,
+		"client": null
+	},
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "listByResourceGroup",
+		"SDKFunctionName": "listByResourceGroup",
+		"params": [],
+		"returnType": null,
+		"client": null
+	},
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "listClusters",
+		"SDKFunctionName": "list",
+		"params": [],
+		"returnType": null,
+		"client": null
+	}
 ]

--- a/generator/test/generators/azure/dummyData/validDataset/files.json
+++ b/generator/test/generators/azure/dummyData/validDataset/files.json
@@ -1,15 +1,15 @@
 [
-  {
-    "fileName": "managedClusters.d.ts",
-    "pkgName": "arm-containerservice",
-    "ast": null,
-    "client": null,
-    "sdkFunctionNames": [
-      "createOrUpdate",
-      "deleteMethod",
-      "updateTags",
-      "listByResourceGroup",
-      "list"
-    ]
-  }
+	{
+		"fileName": "managedClusters.d.ts",
+		"pkgName": "arm-containerservice",
+		"ast": null,
+		"client": null,
+		"sdkFunctionNames": [
+			"createOrUpdate",
+			"deleteMethod",
+			"updateTags",
+			"listByResourceGroup",
+			"list"
+		]
+	}
 ]

--- a/generator/test/generators/azure/dummyData/validDataset/methods.json
+++ b/generator/test/generators/azure/dummyData/validDataset/methods.json
@@ -1,47 +1,47 @@
 [
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "create",
-    "SDKFunctionName": "createOrUpdate",
-    "params": [],
-    "returnType": null,
-    "client": null
-  },
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "delete",
-    "SDKFunctionName": "deleteMethod",
-    "params": [],
-    "returnType": null,
-    "client": null
-  },
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "updateTags",
-    "SDKFunctionName": "updateTags",
-    "params": [],
-    "returnType": null,
-    "client": null
-  },
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "listByResourceGroup",
-    "SDKFunctionName": "listByResourceGroup",
-    "params": [],
-    "returnType": null,
-    "client": null
-  },
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "listClusters",
-    "SDKFunctionName": "list",
-    "params": [],
-    "returnType": null,
-    "client": null
-  }
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "create",
+		"SDKFunctionName": "createOrUpdate",
+		"params": [],
+		"returnType": null,
+		"client": null
+	},
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "delete",
+		"SDKFunctionName": "deleteMethod",
+		"params": [],
+		"returnType": null,
+		"client": null
+	},
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "updateTags",
+		"SDKFunctionName": "updateTags",
+		"params": [],
+		"returnType": null,
+		"client": null
+	},
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "listByResourceGroup",
+		"SDKFunctionName": "listByResourceGroup",
+		"params": [],
+		"returnType": null,
+		"client": null
+	},
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "listClusters",
+		"SDKFunctionName": "list",
+		"params": [],
+		"returnType": null,
+		"client": null
+	}
 ]

--- a/generator/test/generators/azure/generator.test.ts
+++ b/generator/test/generators/azure/generator.test.ts
@@ -1,72 +1,75 @@
-import { expect } from "chai";
-import { SyntaxKind } from "typescript";
+import { expect } from 'chai';
+import { SyntaxKind } from 'typescript';
 
-import { extractSDKData } from "../../../generators/azure/generator";
-import { readJsonData,readSourceFile } from "../lib/helper";
+import { extractSDKData } from '../../../generators/azure/generator';
+import { readJsonData, readSourceFile } from '../lib/helper';
 
-describe("Azure generator extractSDKData", () => {
-  context("with valid methods and valid AST", () => {
-    it("should return class data", async () => {
-      const methods: any = await readJsonData(
-        "validDataset",
-        "azure",
-        "methods"
-      );
+describe('Azure generator extractSDKData', () => {
+	context('with valid methods and valid AST', () => {
+		it('should return class data', async () => {
+			const methods: any = await readJsonData(
+				'validDataset',
+				'azure',
+				'methods'
+			);
 
-      const sdkFiles: any = await readJsonData(
-        "validDataset",
-        "azure",
-        "files"
-      );
+			const sdkFiles: any = await readJsonData(
+				'validDataset',
+				'azure',
+				'files'
+			);
 
-      await Promise.all(
-        sdkFiles.map(async file => {
-          const sdkFile: any = await readSourceFile("validDataset", "azure");
-          sdkFile.forEachChild(child => {
-            if (SyntaxKind[child.kind] === "ClassDeclaration") {
-              file.ast = Object.assign({}, child);
-            }
-          });
-        })
-      );
+			await Promise.all(
+				sdkFiles.map(async file => {
+					const sdkFile: any = await readSourceFile(
+						'validDataset',
+						'azure'
+					);
+					sdkFile.forEachChild(child => {
+						if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+							file.ast = Object.assign({}, child);
+						}
+					});
+				})
+			);
 
-      const result = extractSDKData(sdkFiles, methods);
-      expect(result).to.be.an("object");
-      expect(result.functions).to.be.an("array");
-    });
-  });
+			const result = extractSDKData(sdkFiles, methods);
+			expect(result).to.be.an('object');
+			expect(result.functions).to.be.an('array');
+		});
+	});
 
-  context("AST with no functions", () => {
-    it("should throw error", async () => {
-      const methods: any = await readJsonData(
-        "invalidDataset_1",
-        "azure",
-        "methods"
-      );
+	context('AST with no functions', () => {
+		it('should throw error', async () => {
+			const methods: any = await readJsonData(
+				'invalidDataset_1',
+				'azure',
+				'methods'
+			);
 
-      const sdkFiles: any = await readJsonData(
-        "invalidDataset_1",
-        "azure",
-        "files"
-      );
+			const sdkFiles: any = await readJsonData(
+				'invalidDataset_1',
+				'azure',
+				'files'
+			);
 
-      await Promise.all(
-        sdkFiles.map(async file => {
-          const sdkFile: any = await readSourceFile(
-            "invalidDataset_1",
-            "azure"
-          );
-          sdkFile.forEachChild(child => {
-            if (SyntaxKind[child.kind] === "ClassDeclaration") {
-              file.ast = Object.assign({}, child);
-            }
-          });
-        })
-      );
+			await Promise.all(
+				sdkFiles.map(async file => {
+					const sdkFile: any = await readSourceFile(
+						'invalidDataset_1',
+						'azure'
+					);
+					sdkFile.forEachChild(child => {
+						if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+							file.ast = Object.assign({}, child);
+						}
+					});
+				})
+			);
 
-      expect(function() {
-        extractSDKData(sdkFiles, methods);
-      }).to.throw("Data extraction unsuccessful");
-    });
-  });
+			expect(function() {
+				extractSDKData(sdkFiles, methods);
+			}).to.throw('Data extraction unsuccessful');
+		});
+	});
 });

--- a/generator/test/generators/do/dummyData/invalidDataset_1/serviceClass.json
+++ b/generator/test/generators/do/dummyData/invalidDataset_1/serviceClass.json
@@ -1,8 +1,8 @@
 {
-  "create": "kubernetes.d.ts create",
-  "delete": "kubernetes.d.ts",
-  "listClusters": "kubernetes.d.ts getClusters",
-  "createNodeGroup": "kubernetes.d.ts addNodePool",
-  "deleteNodegroup": " kubernetes.d.ts deleteNodePool",
-  "listNodegroups": "kubernetes.d.ts getNodePools"
+	"create": "kubernetes.d.ts create",
+	"delete": "kubernetes.d.ts",
+	"listClusters": "kubernetes.d.ts getClusters",
+	"createNodeGroup": "kubernetes.d.ts addNodePool",
+	"deleteNodegroup": " kubernetes.d.ts deleteNodePool",
+	"listNodegroups": "kubernetes.d.ts getNodePools"
 }

--- a/generator/test/generators/do/dummyData/invalidDataset_2/serviceClass.json
+++ b/generator/test/generators/do/dummyData/invalidDataset_2/serviceClass.json
@@ -1,8 +1,8 @@
 {
-  "create": "kubernetes.d.ts create",
-  "delete": "kubernetes.d.ts delete",
-  "listClusters": "kubernetes.d.ts getClusters",
-  "createNodeGroup": "kubernetes.d.ts addNodePool",
-  "deleteNodegroup": " kubernetes.d.ts deleteNodePool",
-  "listNodegroups": "kubernetes.d.ts getNodePools"
+	"create": "kubernetes.d.ts create",
+	"delete": "kubernetes.d.ts delete",
+	"listClusters": "kubernetes.d.ts getClusters",
+	"createNodeGroup": "kubernetes.d.ts addNodePool",
+	"deleteNodegroup": " kubernetes.d.ts deleteNodePool",
+	"listNodegroups": "kubernetes.d.ts getNodePools"
 }

--- a/generator/test/generators/do/dummyData/validDataset/serviceClass.json
+++ b/generator/test/generators/do/dummyData/validDataset/serviceClass.json
@@ -1,8 +1,8 @@
 {
-  "create": "kubernetes.d.ts create",
-  "delete": "kubernetes.d.ts delete",
-  "listClusters": "kubernetes.d.ts getClusters",
-  "createNodeGroup": "kubernetes.d.ts addNodePool",
-  "deleteNodegroup": " kubernetes.d.ts deleteNodePool",
-  "listNodegroups": "kubernetes.d.ts getNodePools"
+	"create": "kubernetes.d.ts create",
+	"delete": "kubernetes.d.ts delete",
+	"listClusters": "kubernetes.d.ts getClusters",
+	"createNodeGroup": "kubernetes.d.ts addNodePool",
+	"deleteNodegroup": " kubernetes.d.ts deleteNodePool",
+	"listNodegroups": "kubernetes.d.ts getNodePools"
 }

--- a/generator/test/generators/do/generator.test.ts
+++ b/generator/test/generators/do/generator.test.ts
@@ -1,86 +1,86 @@
-import { expect } from "chai";
-import { SyntaxKind } from "typescript";
+import { expect } from 'chai';
+import { SyntaxKind } from 'typescript';
 
-import { extractSDKData } from "../../../generators/do/generator";
-import { readJsonData,readSourceFile } from "../lib/helper";
+import { extractSDKData } from '../../../generators/do/generator';
+import { readJsonData, readSourceFile } from '../lib/helper';
 
-describe("Digital Ocean generator extractSDKData", () => {
-  context("with valid methods and valid AST", () => {
-    it("should return extracted class data", async () => {
-      const sdkFile: any = await readSourceFile("validDataset", "do");
-      const data: any = await readJsonData(
-        "validDataset",
-        "do",
-        "serviceClass"
-      );
-      let cloned = null;
-      sdkFile.forEachChild(child => {
-        if (SyntaxKind[child.kind] === "ClassDeclaration") {
-          cloned = Object.assign({}, child);
-        }
-      });
+describe('Digital Ocean generator extractSDKData', () => {
+	context('with valid methods and valid AST', () => {
+		it('should return extracted class data', async () => {
+			const sdkFile: any = await readSourceFile('validDataset', 'do');
+			const data: any = await readJsonData(
+				'validDataset',
+				'do',
+				'serviceClass'
+			);
+			let cloned = null;
+			sdkFile.forEachChild(child => {
+				if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+					cloned = Object.assign({}, child);
+				}
+			});
 
-      if (cloned) {
-        const result = extractSDKData(cloned, data);
-        expect(result).to.be.an("object");
-        expect(result.functions).to.be.an("array");
-        expect(result.className).to.be.string;
-      } else {
-        console.error("Error in cloning class");
-      }
-    });
-  });
+			if (cloned) {
+				const result = extractSDKData(cloned, data);
+				expect(result).to.be.an('object');
+				expect(result.functions).to.be.an('array');
+				expect(result.className).to.be.string;
+			} else {
+				console.error('Error in cloning class');
+			}
+		});
+	});
 
-  context("with invalid method data:missing method name", () => {
-    it("should drop invalid method", async () => {
-      const sdkFile: any = await readSourceFile("invalidDataset_1", "do");
-      const data: any = await readJsonData(
-        "invalidDataset_1",
-        "do",
-        "serviceClass"
-      );
-      let cloned = null;
-      sdkFile.forEachChild(child => {
-        if (SyntaxKind[child.kind] === "ClassDeclaration") {
-          cloned = Object.assign({}, child);
-        }
-      });
+	context('with invalid method data:missing method name', () => {
+		it('should drop invalid method', async () => {
+			const sdkFile: any = await readSourceFile('invalidDataset_1', 'do');
+			const data: any = await readJsonData(
+				'invalidDataset_1',
+				'do',
+				'serviceClass'
+			);
+			let cloned = null;
+			sdkFile.forEachChild(child => {
+				if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+					cloned = Object.assign({}, child);
+				}
+			});
 
-      if (cloned) {
-        expect(
-          extractSDKData(cloned, data).functions.length <
-            Object.keys(data).length
-        ).to.be.true;
-      } else {
-        console.error("Error in cloning class");
-      }
-    });
-  });
+			if (cloned) {
+				expect(
+					extractSDKData(cloned, data).functions.length <
+						Object.keys(data).length
+				).to.be.true;
+			} else {
+				console.error('Error in cloning class');
+			}
+		});
+	});
 
-  context("Digital Ocean with no functions", () => {
-    it("should return empty array of methods", async () => {
-      const sdkFile: any = await readSourceFile("invalidDataset_2", "do");
-      const data: any = await readJsonData(
-        "invalidDataset_2",
-        "do",
-        "serviceClass"
-      );
-      let cloned = null;
-      sdkFile.forEachChild(child => {
-        if (SyntaxKind[child.kind] === "ClassDeclaration") {
-          cloned = Object.assign({}, child);
-        }
-      });
+	context('Digital Ocean with no functions', () => {
+		it('should return empty array of methods', async () => {
+			const sdkFile: any = await readSourceFile('invalidDataset_2', 'do');
+			const data: any = await readJsonData(
+				'invalidDataset_2',
+				'do',
+				'serviceClass'
+			);
+			let cloned = null;
+			sdkFile.forEachChild(child => {
+				if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+					cloned = Object.assign({}, child);
+				}
+			});
 
-      if (cloned) {
-        const result = extractSDKData(cloned, data);
-        expect(result).to.be.an("object");
-        expect(result.functions).to.be.an("array");
-        expect(result.className).to.be.string;
-        expect(result.functions.length).to.eql(0);
-      } else {
-        console.error("Error in cloning class");
-      }
-    });
-  });
+			if (cloned) {
+				const result = extractSDKData(cloned, data);
+				expect(result).to.be.an('object');
+				expect(result.functions).to.be.an('array');
+				expect(result.className).to.be.string;
+				expect(result.functions.length).to.eql(0);
+			} else {
+				console.error('Error in cloning class');
+			}
+		});
+	});
 });

--- a/generator/test/generators/googleCloud/dummyData/invalidDataset_1/files.json
+++ b/generator/test/generators/googleCloud/dummyData/invalidDataset_1/files.json
@@ -1,15 +1,15 @@
 [
-  {
-    "fileName": "managedClusters.d.ts",
-    "pkgName": "arm-containerservice",
-    "ast": null,
-    "client": null,
-    "sdkFunctionNames": [
-      "createOrUpdate",
-      "deleteMethod",
-      "updateTags",
-      "listByResourceGroup",
-      "list"
-    ]
-  }
+	{
+		"fileName": "managedClusters.d.ts",
+		"pkgName": "arm-containerservice",
+		"ast": null,
+		"client": null,
+		"sdkFunctionNames": [
+			"createOrUpdate",
+			"deleteMethod",
+			"updateTags",
+			"listByResourceGroup",
+			"list"
+		]
+	}
 ]

--- a/generator/test/generators/googleCloud/dummyData/invalidDataset_1/methods.json
+++ b/generator/test/generators/googleCloud/dummyData/invalidDataset_1/methods.json
@@ -1,47 +1,47 @@
 [
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "create",
-    "SDKFunctionName": "createOrUpdate",
-    "params": [],
-    "returnType": null,
-    "client": null
-  },
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "delete",
-    "SDKFunctionName": "deleteMethod",
-    "params": [],
-    "returnType": null,
-    "client": null
-  },
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "updateTags",
-    "SDKFunctionName": "updateTags",
-    "params": [],
-    "returnType": null,
-    "client": null
-  },
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "listByResourceGroup",
-    "SDKFunctionName": "listByResourceGroup",
-    "params": [],
-    "returnType": null,
-    "client": null
-  },
-  {
-    "pkgName": "arm-containerservice",
-    "fileName": "managedClusters.d.ts",
-    "functionName": "listClusters",
-    "SDKFunctionName": "list",
-    "params": [],
-    "returnType": null,
-    "client": null
-  }
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "create",
+		"SDKFunctionName": "createOrUpdate",
+		"params": [],
+		"returnType": null,
+		"client": null
+	},
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "delete",
+		"SDKFunctionName": "deleteMethod",
+		"params": [],
+		"returnType": null,
+		"client": null
+	},
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "updateTags",
+		"SDKFunctionName": "updateTags",
+		"params": [],
+		"returnType": null,
+		"client": null
+	},
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "listByResourceGroup",
+		"SDKFunctionName": "listByResourceGroup",
+		"params": [],
+		"returnType": null,
+		"client": null
+	},
+	{
+		"pkgName": "arm-containerservice",
+		"fileName": "managedClusters.d.ts",
+		"functionName": "listClusters",
+		"SDKFunctionName": "list",
+		"params": [],
+		"returnType": null,
+		"client": null
+	}
 ]

--- a/generator/test/generators/googleCloud/dummyData/invalidDataset_2/files.json
+++ b/generator/test/generators/googleCloud/dummyData/invalidDataset_2/files.json
@@ -1,10 +1,10 @@
 [
-  {
-    "fileName": "cluster_manager_client.d.ts",
-    "version": "v1",
-    "pkgName": "container",
-    "ast": null,
-    "client": null,
-    "sdkFunctionNames": ["createCluster", "deleteCluster", "listClusters"]
-  }
+	{
+		"fileName": "cluster_manager_client.d.ts",
+		"version": "v1",
+		"pkgName": "container",
+		"ast": null,
+		"client": null,
+		"sdkFunctionNames": ["createCluster", "deleteCluster", "listClusters"]
+	}
 ]

--- a/generator/test/generators/googleCloud/dummyData/invalidDataset_2/methods.json
+++ b/generator/test/generators/googleCloud/dummyData/invalidDataset_2/methods.json
@@ -1,35 +1,35 @@
 [
-  {
-    "pkgName": "container",
-    "version": "v1",
-    "fileName": "cluster_manager_client.d.ts",
-    "functionName": "create",
-    "SDKFunctionName": "createCluster",
-    "params": [],
-    "returnType": null,
-    "returnTypeName": null,
-    "client": null
-  },
-  {
-    "pkgName": "container",
-    "version": "v1",
-    "fileName": "cluster_manager_client.d.ts",
-    "functionName": "delete",
-    "SDKFunctionName": "deleteCluster",
-    "params": [],
-    "returnType": null,
-    "returnTypeName": null,
-    "client": null
-  },
-  {
-    "pkgName": "container",
-    "version": "v1",
-    "fileName": "cluster_manager_client.d.ts",
-    "functionName": "listClusters",
-    "SDKFunctionName": "listClusters",
-    "params": [],
-    "returnType": null,
-    "returnTypeName": null,
-    "client": null
-  }
+	{
+		"pkgName": "container",
+		"version": "v1",
+		"fileName": "cluster_manager_client.d.ts",
+		"functionName": "create",
+		"SDKFunctionName": "createCluster",
+		"params": [],
+		"returnType": null,
+		"returnTypeName": null,
+		"client": null
+	},
+	{
+		"pkgName": "container",
+		"version": "v1",
+		"fileName": "cluster_manager_client.d.ts",
+		"functionName": "delete",
+		"SDKFunctionName": "deleteCluster",
+		"params": [],
+		"returnType": null,
+		"returnTypeName": null,
+		"client": null
+	},
+	{
+		"pkgName": "container",
+		"version": "v1",
+		"fileName": "cluster_manager_client.d.ts",
+		"functionName": "listClusters",
+		"SDKFunctionName": "listClusters",
+		"params": [],
+		"returnType": null,
+		"returnTypeName": null,
+		"client": null
+	}
 ]

--- a/generator/test/generators/googleCloud/dummyData/validDataset_1/files.json
+++ b/generator/test/generators/googleCloud/dummyData/validDataset_1/files.json
@@ -1,26 +1,26 @@
 [
-  {
-    "fileName": "change.d.ts",
-    "pkgName": "dns",
-    "classes": null,
-    "sdkFunctionNames": []
-  },
-  {
-    "fileName": "index.d.ts",
-    "pkgName": "dns",
-    "classes": null,
-    "sdkFunctionNames": ["getZones"]
-  },
-  {
-    "fileName": "record.d.ts",
-    "pkgName": "dns",
-    "classes": null,
-    "sdkFunctionNames": []
-  },
-  {
-    "fileName": "zone.d.ts",
-    "pkgName": "dns",
-    "classes": null,
-    "sdkFunctionNames": ["create"]
-  }
+	{
+		"fileName": "change.d.ts",
+		"pkgName": "dns",
+		"classes": null,
+		"sdkFunctionNames": []
+	},
+	{
+		"fileName": "index.d.ts",
+		"pkgName": "dns",
+		"classes": null,
+		"sdkFunctionNames": ["getZones"]
+	},
+	{
+		"fileName": "record.d.ts",
+		"pkgName": "dns",
+		"classes": null,
+		"sdkFunctionNames": []
+	},
+	{
+		"fileName": "zone.d.ts",
+		"pkgName": "dns",
+		"classes": null,
+		"sdkFunctionNames": ["create"]
+	}
 ]

--- a/generator/test/generators/googleCloud/dummyData/validDataset_1/methods.json
+++ b/generator/test/generators/googleCloud/dummyData/validDataset_1/methods.json
@@ -1,24 +1,24 @@
 [
-  {
-    "pkgName": "dns",
-    "version": null,
-    "fileName": "index.d.ts",
-    "functionName": "listZones",
-    "SDKFunctionName": "getZones",
-    "params": [],
-    "returnType": null,
-    "returnTypeName": null,
-    "client": null
-  },
-  {
-    "pkgName": "dns",
-    "version": null,
-    "fileName": "zone.d.ts",
-    "functionName": "createZone",
-    "SDKFunctionName": "create",
-    "params": [],
-    "returnType": null,
-    "returnTypeName": null,
-    "client": null
-  }
+	{
+		"pkgName": "dns",
+		"version": null,
+		"fileName": "index.d.ts",
+		"functionName": "listZones",
+		"SDKFunctionName": "getZones",
+		"params": [],
+		"returnType": null,
+		"returnTypeName": null,
+		"client": null
+	},
+	{
+		"pkgName": "dns",
+		"version": null,
+		"fileName": "zone.d.ts",
+		"functionName": "createZone",
+		"SDKFunctionName": "create",
+		"params": [],
+		"returnType": null,
+		"returnTypeName": null,
+		"client": null
+	}
 ]

--- a/generator/test/generators/googleCloud/dummyData/validDataset_2/files.json
+++ b/generator/test/generators/googleCloud/dummyData/validDataset_2/files.json
@@ -1,10 +1,10 @@
 [
-  {
-    "fileName": "cluster_manager_client.d.ts",
-    "version": "v1",
-    "pkgName": "container",
-    "ast": null,
-    "client": null,
-    "sdkFunctionNames": ["createCluster", "deleteCluster", "listClusters"]
-  }
+	{
+		"fileName": "cluster_manager_client.d.ts",
+		"version": "v1",
+		"pkgName": "container",
+		"ast": null,
+		"client": null,
+		"sdkFunctionNames": ["createCluster", "deleteCluster", "listClusters"]
+	}
 ]

--- a/generator/test/generators/googleCloud/dummyData/validDataset_2/methods.json
+++ b/generator/test/generators/googleCloud/dummyData/validDataset_2/methods.json
@@ -1,35 +1,35 @@
 [
-  {
-    "pkgName": "container",
-    "version": "v1",
-    "fileName": "cluster_manager_client.d.ts",
-    "functionName": "create",
-    "SDKFunctionName": "createCluster",
-    "params": [],
-    "returnType": null,
-    "returnTypeName": null,
-    "client": null
-  },
-  {
-    "pkgName": "container",
-    "version": "v1",
-    "fileName": "cluster_manager_client.d.ts",
-    "functionName": "delete",
-    "SDKFunctionName": "deleteCluster",
-    "params": [],
-    "returnType": null,
-    "returnTypeName": null,
-    "client": null
-  },
-  {
-    "pkgName": "container",
-    "version": "v1",
-    "fileName": "cluster_manager_client.d.ts",
-    "functionName": "listClusters",
-    "SDKFunctionName": "listClusters",
-    "params": [],
-    "returnType": null,
-    "returnTypeName": null,
-    "client": null
-  }
+	{
+		"pkgName": "container",
+		"version": "v1",
+		"fileName": "cluster_manager_client.d.ts",
+		"functionName": "create",
+		"SDKFunctionName": "createCluster",
+		"params": [],
+		"returnType": null,
+		"returnTypeName": null,
+		"client": null
+	},
+	{
+		"pkgName": "container",
+		"version": "v1",
+		"fileName": "cluster_manager_client.d.ts",
+		"functionName": "delete",
+		"SDKFunctionName": "deleteCluster",
+		"params": [],
+		"returnType": null,
+		"returnTypeName": null,
+		"client": null
+	},
+	{
+		"pkgName": "container",
+		"version": "v1",
+		"fileName": "cluster_manager_client.d.ts",
+		"functionName": "listClusters",
+		"SDKFunctionName": "listClusters",
+		"params": [],
+		"returnType": null,
+		"returnTypeName": null,
+		"client": null
+	}
 ]

--- a/generator/test/generators/googleCloud/generator.test.ts
+++ b/generator/test/generators/googleCloud/generator.test.ts
@@ -1,159 +1,163 @@
-import { expect } from "chai";
-import { SyntaxKind } from "typescript";
+import { expect } from 'chai';
+import { SyntaxKind } from 'typescript';
 
 import {
-  extractClassBasedSDKData,
-  extractClientBasedSDKdata
-} from "../../../generators/googleCloud/generator";
-import { readJsonData, readSourceFile } from "../lib/helper";
+	extractClassBasedSDKData,
+	extractClientBasedSDKdata,
+} from '../../../generators/googleCloud/generator';
+import { readJsonData, readSourceFile } from '../lib/helper';
 
-describe("GCP generator extractClassBasedSDKData", () => {
-  context("with valid methods and valid AST", () => {
-    it("should return class data", async () => {
-      const methods: any = await readJsonData(
-        "validDataset_1",
-        "googleCloud",
-        "methods"
-      );
+describe('GCP generator extractClassBasedSDKData', () => {
+	context('with valid methods and valid AST', () => {
+		it('should return class data', async () => {
+			const methods: any = await readJsonData(
+				'validDataset_1',
+				'googleCloud',
+				'methods'
+			);
 
-      const sdkFiles: any = await readJsonData(
-        "validDataset_1",
-        "googleCloud",
-        "files"
-      );
+			const sdkFiles: any = await readJsonData(
+				'validDataset_1',
+				'googleCloud',
+				'files'
+			);
 
-      await Promise.all(
-        sdkFiles.map(async file => {
-          file.classes = [];
-          const sdkFile: any = await readSourceFile(
-            "validDataset_1",
-            "googleCloud"
-          );
-          sdkFile.forEachChild(child => {
-            if (SyntaxKind[child.kind] === "ClassDeclaration") {
-              let cloned = Object.assign({}, child);
-              file.classes.push(cloned);
-            }
-          });
-        })
-      );
+			await Promise.all(
+				sdkFiles.map(async file => {
+					file.classes = [];
+					const sdkFile: any = await readSourceFile(
+						'validDataset_1',
+						'googleCloud'
+					);
+					sdkFile.forEachChild(child => {
+						if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+							let cloned = Object.assign({}, child);
+							file.classes.push(cloned);
+						}
+					});
+				})
+			);
 
-      extractClassBasedSDKData(methods, sdkFiles).then(result => {
-        expect(result).to.be.an("object");
-        expect(result.methods).to.be.an("array");
-      });
-    });
-  });
+			extractClassBasedSDKData(methods, sdkFiles).then(result => {
+				expect(result).to.be.an('object');
+				expect(result.methods).to.be.an('array');
+			});
+		});
+	});
 
-  context("with invalid AST", () => {
-    it("should return Error", async () => {
-      const methods: any = await readJsonData(
-        "invalidDataset_1",
-        "googleCloud",
-        "methods"
-      );
+	context('with invalid AST', () => {
+		it('should return Error', async () => {
+			const methods: any = await readJsonData(
+				'invalidDataset_1',
+				'googleCloud',
+				'methods'
+			);
 
-      const sdkFiles: any = await readJsonData(
-        "invalidDataset_1",
-        "googleCloud",
-        "files"
-      );
+			const sdkFiles: any = await readJsonData(
+				'invalidDataset_1',
+				'googleCloud',
+				'files'
+			);
 
-      await Promise.all(
-        sdkFiles.map(async file => {
-          file.classes = [];
-          const sdkFile: any = await readSourceFile(
-            "invalidDataset_1",
-            "googleCloud"
-          );
-          sdkFile.forEachChild(child => {
-            if (SyntaxKind[child.kind] === "ClassDeclaration") {
-              let cloned = Object.assign({}, child);
-              file.classes.push(cloned);
-            }
-          });
-        })
-      );
+			await Promise.all(
+				sdkFiles.map(async file => {
+					file.classes = [];
+					const sdkFile: any = await readSourceFile(
+						'invalidDataset_1',
+						'googleCloud'
+					);
+					sdkFile.forEachChild(child => {
+						if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+							let cloned = Object.assign({}, child);
+							file.classes.push(cloned);
+						}
+					});
+				})
+			);
 
-      extractClassBasedSDKData(methods, sdkFiles).then(
-        result => {},
-        error => {
-          expect(error.message).to.eql("Data extraction unsuccessful");
-        }
-      );
-    });
-  });
+			extractClassBasedSDKData(methods, sdkFiles).then(
+				result => {},
+				error => {
+					expect(error.message).to.eql(
+						'Data extraction unsuccessful'
+					);
+				}
+			);
+		});
+	});
 });
 
-describe("GCP generator extractClientBasedSDKdata", () => {
-  context("with valid methods and valid AST", () => {
-    it("should return class data", async () => {
-      const methods: any = await readJsonData(
-        "validDataset_2",
-        "googleCloud",
-        "methods"
-      );
+describe('GCP generator extractClientBasedSDKdata', () => {
+	context('with valid methods and valid AST', () => {
+		it('should return class data', async () => {
+			const methods: any = await readJsonData(
+				'validDataset_2',
+				'googleCloud',
+				'methods'
+			);
 
-      const sdkFiles: any = await readJsonData(
-        "validDataset_2",
-        "googleCloud",
-        "files"
-      );
+			const sdkFiles: any = await readJsonData(
+				'validDataset_2',
+				'googleCloud',
+				'files'
+			);
 
-      await Promise.all(
-        sdkFiles.map(async file => {
-          const sdkFile: any = await readSourceFile(
-            "validDataset_2",
-            "googleCloud"
-          );
-          sdkFile.forEachChild(child => {
-            if (SyntaxKind[child.kind] === "ClassDeclaration") {
-              file.ast = Object.assign({}, child);
-            }
-          });
-        })
-      );
+			await Promise.all(
+				sdkFiles.map(async file => {
+					const sdkFile: any = await readSourceFile(
+						'validDataset_2',
+						'googleCloud'
+					);
+					sdkFile.forEachChild(child => {
+						if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+							file.ast = Object.assign({}, child);
+						}
+					});
+				})
+			);
 
-      extractClientBasedSDKdata(methods, sdkFiles).then(result => {
-        expect(result).to.be.an("array");
-      });
-    });
-  });
+			extractClientBasedSDKdata(methods, sdkFiles).then(result => {
+				expect(result).to.be.an('array');
+			});
+		});
+	});
 
-  context("with invalid AST", () => {
-    it("should return Error", async () => {
-      const methods: any = await readJsonData(
-        "invalidDataset_2",
-        "googleCloud",
-        "methods"
-      );
+	context('with invalid AST', () => {
+		it('should return Error', async () => {
+			const methods: any = await readJsonData(
+				'invalidDataset_2',
+				'googleCloud',
+				'methods'
+			);
 
-      const sdkFiles: any = await readJsonData(
-        "invalidDataset_2",
-        "googleCloud",
-        "files"
-      );
+			const sdkFiles: any = await readJsonData(
+				'invalidDataset_2',
+				'googleCloud',
+				'files'
+			);
 
-      await Promise.all(
-        sdkFiles.map(async file => {
-          const sdkFile: any = await readSourceFile(
-            "invalidDataset_2",
-            "googleCloud"
-          );
-          sdkFile.forEachChild(child => {
-            if (SyntaxKind[child.kind] === "ClassDeclaration") {
-              file.ast = Object.assign({}, child);
-            }
-          });
-        })
-      );
+			await Promise.all(
+				sdkFiles.map(async file => {
+					const sdkFile: any = await readSourceFile(
+						'invalidDataset_2',
+						'googleCloud'
+					);
+					sdkFile.forEachChild(child => {
+						if (SyntaxKind[child.kind] === 'ClassDeclaration') {
+							file.ast = Object.assign({}, child);
+						}
+					});
+				})
+			);
 
-      extractClientBasedSDKdata(methods, sdkFiles).then(
-        result => {},
-        error => {
-          expect(error.message).to.eql("Data extraction unsuccessful");
-        }
-      );
-    });
-  });
+			extractClientBasedSDKdata(methods, sdkFiles).then(
+				result => {},
+				error => {
+					expect(error.message).to.eql(
+						'Data extraction unsuccessful'
+					);
+				}
+			);
+		});
+	});
 });

--- a/generator/test/generators/lib/helper.ts
+++ b/generator/test/generators/lib/helper.ts
@@ -1,35 +1,35 @@
-import * as fs from "fs";
-import { createSourceFile,ScriptTarget } from "typescript";
+import * as fs from 'fs';
+import { createSourceFile, ScriptTarget } from 'typescript';
 
 export function readSourceFile(datasetName, provider) {
-  return new Promise((resolve, reject) => {
-    try {
-      const testFile =
-        process.cwd() +
-        `/test/generators/${provider}/dummyData/${datasetName}/sdkFile.txt`;
-      const testAST = createSourceFile(
-        testFile,
-        fs.readFileSync(testFile).toString(),
-        ScriptTarget.Latest,
-        true
-      );
-      resolve(testAST);
-    } catch (error) {
-      console.error(error);
-    }
-  });
+	return new Promise((resolve, reject) => {
+		try {
+			const testFile =
+				process.cwd() +
+				`/test/generators/${provider}/dummyData/${datasetName}/sdkFile.txt`;
+			const testAST = createSourceFile(
+				testFile,
+				fs.readFileSync(testFile).toString(),
+				ScriptTarget.Latest,
+				true
+			);
+			resolve(testAST);
+		} catch (error) {
+			console.error(error);
+		}
+	});
 }
 
 export function readJsonData(datasetName, provider, fileName) {
-  return new Promise((resolve, reject) => {
-    try {
-      const testFile =
-        process.cwd() +
-        `/test/generators/${provider}/dummyData/${datasetName}/${fileName}.json`;
-      const testData = JSON.parse(fs.readFileSync(testFile, "utf8"));
-      resolve(testData);
-    } catch (error) {
-      console.error(error);
-    }
-  });
+	return new Promise((resolve, reject) => {
+		try {
+			const testFile =
+				process.cwd() +
+				`/test/generators/${provider}/dummyData/${datasetName}/${fileName}.json`;
+			const testData = JSON.parse(fs.readFileSync(testFile, 'utf8'));
+			resolve(testData);
+		} catch (error) {
+			console.error(error);
+		}
+	});
 }

--- a/generator/test/parsers/aliyun/parser.test.ts
+++ b/generator/test/parsers/aliyun/parser.test.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { SyntaxKind } from 'typescript';
+
+import { getAST } from '../../../parsers/aliyun/parser';
+
+describe('Aliyun getAST Implementation', () => {
+	const sdkFilePath = 'oss index.d.ts setRegion';
+	const invalidPath = 'oss unknown.d.ts setRegion';
+	context('With existing file', () => {
+		it('Should return Abstract syntax tree of the class', async () => {
+			const ast: any = await getAST(sdkFilePath);
+			expect(ast).to.be.an('object');
+			expect(SyntaxKind[ast.kind] === 'ClassDeclaration').to.be.true;
+		});
+	});
+
+	context('With non-existing file', () => {
+		it('should return File not found Error', async () => {
+			try {
+				await getAST(invalidPath);
+			} catch (error) {
+				expect(error.message).to.eql('File not found!');
+			}
+		});
+	});
+});

--- a/generator/test/parsers/aws/parser.test.ts
+++ b/generator/test/parsers/aws/parser.test.ts
@@ -1,34 +1,34 @@
-import { expect } from "chai";
-import { SyntaxKind } from "typescript";
+import { expect } from 'chai';
+import { SyntaxKind } from 'typescript';
 
-import { getAST } from "../../../parsers/aws/parser";
+import { getAST } from '../../../parsers/aws/parser';
 
-describe("AWS parser getAST", () => {
-  context("with existing file", () => {
-    it("should return Abstract syntax tree of the class", async () => {
-      const ast: any = await getAST("amplify.d.ts");
-      expect(ast).to.be.an("object");
-      expect(SyntaxKind[ast.kind] === "ClassDeclaration").to.be.true;
-    });
-  });
+describe('AWS parser getAST', () => {
+	context('with existing file', () => {
+		it('should return Abstract syntax tree of the class', async () => {
+			const ast: any = await getAST('amplify.d.ts');
+			expect(ast).to.be.an('object');
+			expect(SyntaxKind[ast.kind] === 'ClassDeclaration').to.be.true;
+		});
+	});
 
-  context("with non-existing file", () => {
-    it("should return File not found Error", async () => {
-      try {
-        await getAST("unknown.d.ts");
-      } catch (error) {
-        expect(error.message).to.eql("File not found!");
-      }
-    });
-  });
+	context('with non-existing file', () => {
+		it('should return File not found Error', async () => {
+			try {
+				await getAST('unknown.d.ts');
+			} catch (error) {
+				expect(error.message).to.eql('File not found!');
+			}
+		});
+	});
 
-  context("with wrong format file", () => {
-    it("should return class not found Error", async () => {
-      try {
-        await getAST("browser_default.d.ts");
-      } catch (error) {
-        expect(error.message).to.eql("Class not found!");
-      }
-    });
-  });
+	context('with wrong format file', () => {
+		it('should return class not found Error', async () => {
+			try {
+				await getAST('browser_default.d.ts');
+			} catch (error) {
+				expect(error.message).to.eql('Class not found!');
+			}
+		});
+	});
 });

--- a/generator/test/parsers/azure/parser.test.ts
+++ b/generator/test/parsers/azure/parser.test.ts
@@ -1,38 +1,41 @@
-import { expect } from "chai";
-import { SyntaxKind } from "typescript";
+import { expect } from 'chai';
+import { SyntaxKind } from 'typescript';
 
-import { getAST } from "../../../parsers/azure/parser";
+import { getAST } from '../../../parsers/azure/parser';
 
-describe("Azure parser getAST", () => {
-  context("with existing file", () => {
-    it("should return Abstract syntax tree of the class", async () => {
-      const ast: any = await getAST({
-        pkgName: "arm-containerservice",
-        fileName: "managedClusters.d.ts"
-      });
-      expect(ast).to.be.an("object");
-      expect(SyntaxKind[ast.kind] === "ClassDeclaration").to.be.true;
-    });
-  });
+describe('Azure parser getAST', () => {
+	context('with existing file', () => {
+		it('should return Abstract syntax tree of the class', async () => {
+			const ast: any = await getAST({
+				pkgName: 'arm-containerservice',
+				fileName: 'managedClusters.d.ts',
+			});
+			expect(ast).to.be.an('object');
+			expect(SyntaxKind[ast.kind] === 'ClassDeclaration').to.be.true;
+		});
+	});
 
-  context("with non-existing file", () => {
-    it("should return File not found Error", async () => {
-      try {
-        await getAST("unknown.d.ts");
-      } catch (error) {
-        expect(error.message).to.eql("File not found!");
-      }
-    });
-  });
+	context('with non-existing file', () => {
+		it('should return File not found Error', async () => {
+			try {
+				await getAST('unknown.d.ts');
+			} catch (error) {
+				expect(error.message).to.eql('File not found!');
+			}
+		});
+	});
 
-  context("with wrong format file", () => {
-    it("should return class not found Error", async () => {
-      try {
-        const fileInfo = { pkgName: "arm-storage", fileName: "index.d.ts" };
-        await getAST(fileInfo);
-      } catch (error) {
-        expect(error.message).to.eql("Class not found!");
-      }
-    });
-  });
+	context('with wrong format file', () => {
+		it('should return class not found Error', async () => {
+			try {
+				const fileInfo = {
+					pkgName: 'arm-storage',
+					fileName: 'index.d.ts',
+				};
+				await getAST(fileInfo);
+			} catch (error) {
+				expect(error.message).to.eql('Class not found!');
+			}
+		});
+	});
 });

--- a/generator/test/parsers/do/parser.test.ts
+++ b/generator/test/parsers/do/parser.test.ts
@@ -1,34 +1,34 @@
-import { expect } from "chai";
-import { SyntaxKind } from "typescript";
+import { expect } from 'chai';
+import { SyntaxKind } from 'typescript';
 
-import { getAST } from "../../../parsers/do/parser";
+import { getAST } from '../../../parsers/do/parser';
 
-describe("Digital Ocean parser getAST", () => {
-  context("With existing file", () => {
-    it("Should return Abstract syntax tree of the class", async () => {
-      const ast: any = await getAST("droplets.d.ts");
-      expect(ast).to.be.an("object");
-      expect(SyntaxKind[ast.kind] === "ClassDeclaration").to.be.true;
-    });
-  });
+describe('Digital Ocean parser getAST', () => {
+	context('With existing file', () => {
+		it('Should return Abstract syntax tree of the class', async () => {
+			const ast: any = await getAST('droplets.d.ts');
+			expect(ast).to.be.an('object');
+			expect(SyntaxKind[ast.kind] === 'ClassDeclaration').to.be.true;
+		});
+	});
 
-  context("With non-existing file", () => {
-    it("should return File not found Error", async () => {
-      try {
-        await getAST("unknown.d.ts");
-      } catch (error) {
-        expect(error.message).to.eql("File not found!");
-      }
-    });
-  });
+	context('With non-existing file', () => {
+		it('should return File not found Error', async () => {
+			try {
+				await getAST('unknown.d.ts');
+			} catch (error) {
+				expect(error.message).to.eql('File not found!');
+			}
+		});
+	});
 
-  context("With wrong format file", () => {
-    it("Should return class not found Error", async () => {
-      try {
-        await getAST("../types/common.d.ts");
-      } catch (error) {
-        expect(error.message).to.eql("Class not found!");
-      }
-    });
-  });
+	context('With wrong format file', () => {
+		it('Should return class not found Error', async () => {
+			try {
+				await getAST('../types/common.d.ts');
+			} catch (error) {
+				expect(error.message).to.eql('Class not found!');
+			}
+		});
+	});
 });

--- a/generator/test/parsers/googleCloud/parser.test.ts
+++ b/generator/test/parsers/googleCloud/parser.test.ts
@@ -1,64 +1,64 @@
-import { expect } from "chai";
-import { SyntaxKind } from "typescript";
+import { expect } from 'chai';
+import { SyntaxKind } from 'typescript';
 
-import { getAST } from "../../../parsers/googleCloud/parser";
+import { getAST } from '../../../parsers/googleCloud/parser';
 
-describe("Google cloud parser getAST", () => {
-  context("with existing file, multi:false", () => {
-    it("should return Abstract syntax tree of the class", async () => {
-      const fileInfo = {
-        pkgName: "monitoring",
-        version: "v3",
-        fileName: "alert_policy_service_client.d.ts"
-      };
-      const ast: any = await getAST(fileInfo);
-      expect(ast).to.be.an("object");
-      expect(SyntaxKind[ast.kind] === "ClassDeclaration").to.be.true;
-    });
-  });
+describe('Google cloud parser getAST', () => {
+	context('with existing file, multi:false', () => {
+		it('should return Abstract syntax tree of the class', async () => {
+			const fileInfo = {
+				pkgName: 'monitoring',
+				version: 'v3',
+				fileName: 'alert_policy_service_client.d.ts',
+			};
+			const ast: any = await getAST(fileInfo);
+			expect(ast).to.be.an('object');
+			expect(SyntaxKind[ast.kind] === 'ClassDeclaration').to.be.true;
+		});
+	});
 
-  context("with existing file, multi:true", () => {
-    it("should return an array of Abstract syntax tree classes", async () => {
-      const fileInfo = { pkgName: "dns", fileName: "zone.d.ts" };
-      const classes: any = await getAST(fileInfo, true);
-      expect(classes).to.be.an("array");
-      classes.forEach((elt, index) => {
-        expect(SyntaxKind[elt.kind] === "ClassDeclaration").to.be.true;
-      });
-    });
-  });
+	context('with existing file, multi:true', () => {
+		it('should return an array of Abstract syntax tree classes', async () => {
+			const fileInfo = { pkgName: 'dns', fileName: 'zone.d.ts' };
+			const classes: any = await getAST(fileInfo, true);
+			expect(classes).to.be.an('array');
+			classes.forEach((elt, index) => {
+				expect(SyntaxKind[elt.kind] === 'ClassDeclaration').to.be.true;
+			});
+		});
+	});
 
-  context("with non-existing file", () => {
-    it("should return File not found Error", async () => {
-      try {
-        await getAST("unknown.d.ts");
-      } catch (error) {
-        expect(error.message).to.eql("File not found!");
-      }
-    });
-  });
+	context('with non-existing file', () => {
+		it('should return File not found Error', async () => {
+			try {
+				await getAST('unknown.d.ts');
+			} catch (error) {
+				expect(error.message).to.eql('File not found!');
+			}
+		});
+	});
 
-  context("with wrong format file, multi:true", () => {
-    it("should return an empty array", async () => {
-      const fileInfo = { pkgName: "storage", fileName: "index.d.ts" };
-      const classes: any = await getAST(fileInfo, true);
-      expect(classes).to.be.an("array");
-      expect(classes.length).to.be.equal(0);
-    });
-  });
+	context('with wrong format file, multi:true', () => {
+		it('should return an empty array', async () => {
+			const fileInfo = { pkgName: 'storage', fileName: 'index.d.ts' };
+			const classes: any = await getAST(fileInfo, true);
+			expect(classes).to.be.an('array');
+			expect(classes.length).to.be.equal(0);
+		});
+	});
 
-  context("with wrong format file", () => {
-    it("should return a Class not found Error", async () => {
-      const fileInfo = {
-        pkgName: "monitoring",
-        version: "v3",
-        fileName: "index.d.ts"
-      };
-      try {
-        const ast: any = await getAST(fileInfo);
-      } catch (error) {
-        expect(error.message).to.eql("Class not found!");
-      }
-    });
-  });
+	context('with wrong format file', () => {
+		it('should return a Class not found Error', async () => {
+			const fileInfo = {
+				pkgName: 'monitoring',
+				version: 'v3',
+				fileName: 'index.d.ts',
+			};
+			try {
+				const ast: any = await getAST(fileInfo);
+			} catch (error) {
+				expect(error.message).to.eql('Class not found!');
+			}
+		});
+	});
 });

--- a/generator/test/transformers/aws/dummyData/invalidDataset_1/data.json
+++ b/generator/test/transformers/aws/dummyData/invalidDataset_1/data.json
@@ -1,104 +1,104 @@
 {
-  "className": "SimpleDB",
-  "functions": [
-    {
-      "functionName": "batchDelete",
-      "SDKFunctionName": "batchDeleteAttributes",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "batchWrite",
-      "SDKFunctionName": "batchPutAttributes",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "createCollection",
-      "SDKFunctionName": "createDomain",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "deleteAttribute",
-      "SDKFunctionName": "deleteAttributes",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "deleteCollection",
-      "SDKFunctionName": "deleteDomain",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "getAttributes",
-      "SDKFunctionName": "getAttributes",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "listCollections",
-      "SDKFunctionName": "listDomains",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "setAttribute",
-      "SDKFunctionName": "putAttributes",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "query",
-      "SDKFunctionName": "select",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    }
-  ]
+	"className": "SimpleDB",
+	"functions": [
+		{
+			"functionName": "batchDelete",
+			"SDKFunctionName": "batchDeleteAttributes",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "batchWrite",
+			"SDKFunctionName": "batchPutAttributes",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "createCollection",
+			"SDKFunctionName": "createDomain",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "deleteAttribute",
+			"SDKFunctionName": "deleteAttributes",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "deleteCollection",
+			"SDKFunctionName": "deleteDomain",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "getAttributes",
+			"SDKFunctionName": "getAttributes",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "listCollections",
+			"SDKFunctionName": "listDomains",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "setAttribute",
+			"SDKFunctionName": "putAttributes",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "query",
+			"SDKFunctionName": "select",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		}
+	]
 }

--- a/generator/test/transformers/aws/dummyData/invalidDataset_2/data.json
+++ b/generator/test/transformers/aws/dummyData/invalidDataset_2/data.json
@@ -1,15 +1,15 @@
 {
-  "functions": [
-    {
-      "SDKFunctionName": "batchDeleteAttributes",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference",
-          "invalid": true
-        }
-      ]
-    }
-  ]
+	"functions": [
+		{
+			"SDKFunctionName": "batchDeleteAttributes",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference",
+					"invalid": true
+				}
+			]
+		}
+	]
 }

--- a/generator/test/transformers/aws/dummyData/validDataset/data.json
+++ b/generator/test/transformers/aws/dummyData/validDataset/data.json
@@ -1,104 +1,104 @@
 {
-  "className": "SimpleDB",
-  "functions": [
-    {
-      "functionName": "batchDelete",
-      "SDKFunctionName": "batchDeleteAttributes",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "batchWrite",
-      "SDKFunctionName": "batchPutAttributes",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "createCollection",
-      "SDKFunctionName": "createDomain",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "deleteAttribute",
-      "SDKFunctionName": "deleteAttributes",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "deleteCollection",
-      "SDKFunctionName": "deleteDomain",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "getAttributes",
-      "SDKFunctionName": "getAttributes",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "listCollections",
-      "SDKFunctionName": "listDomains",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "setAttribute",
-      "SDKFunctionName": "putAttributes",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    },
-    {
-      "functionName": "query",
-      "SDKFunctionName": "select",
-      "params": [
-        {
-          "name": "params",
-          "optional": false,
-          "type": "TypeReference"
-        }
-      ]
-    }
-  ]
+	"className": "SimpleDB",
+	"functions": [
+		{
+			"functionName": "batchDelete",
+			"SDKFunctionName": "batchDeleteAttributes",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "batchWrite",
+			"SDKFunctionName": "batchPutAttributes",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "createCollection",
+			"SDKFunctionName": "createDomain",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "deleteAttribute",
+			"SDKFunctionName": "deleteAttributes",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "deleteCollection",
+			"SDKFunctionName": "deleteDomain",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "getAttributes",
+			"SDKFunctionName": "getAttributes",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "listCollections",
+			"SDKFunctionName": "listDomains",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "setAttribute",
+			"SDKFunctionName": "putAttributes",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		},
+		{
+			"functionName": "query",
+			"SDKFunctionName": "select",
+			"params": [
+				{
+					"name": "params",
+					"optional": false,
+					"type": "TypeReference"
+				}
+			]
+		}
+	]
 }

--- a/generator/test/transformers/aws/transformer.test.ts
+++ b/generator/test/transformers/aws/transformer.test.ts
@@ -1,71 +1,71 @@
-import { expect } from "chai";
-import { createSourceFile, isSourceFile,ScriptTarget } from "typescript";
+import { expect } from 'chai';
+import { createSourceFile, isSourceFile, ScriptTarget } from 'typescript';
 
-import { transform } from "../../../transformers/aws/transformer";
-import { readJsonData, readSourceFile } from "../lib/helper";
+import { transform } from '../../../transformers/aws/transformer';
+import { readJsonData, readSourceFile } from '../lib/helper';
 
 interface TestData {
-  AST: any;
-  data: any;
+	AST: any;
+	data: any;
 }
 
-describe("AWS transformer transform", () => {
-  context("Valid source code and valid data", () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile("validDataset", "aws");
-      testData.data = await readJsonData("validDataset", "aws");
-    });
+describe('AWS transformer transform', () => {
+	context('Valid source code and valid data', () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile('validDataset', 'aws');
+			testData.data = await readJsonData('validDataset', 'aws');
+		});
 
-    it("Should return a String", async () => {
-      const result = await transform(testData.AST, testData.data);
-      expect(result).to.be.string;
-    });
+		it('Should return a String', async () => {
+			const result = await transform(testData.AST, testData.data);
+			expect(result).to.be.string;
+		});
 
-    it("Should return a Javascript code in String format", async () => {
-      const result = await transform(testData.AST, testData.data);
-      try {
-        const sourceCode = createSourceFile(
-          "someClass.js",
-          result,
-          ScriptTarget.Latest
-        );
-        expect(isSourceFile(sourceCode)).to.be.true;
-      } catch (error) {
-        console.log(error);
-      }
-    });
-  });
+		it('Should return a Javascript code in String format', async () => {
+			const result = await transform(testData.AST, testData.data);
+			try {
+				const sourceCode = createSourceFile(
+					'someClass.js',
+					result,
+					ScriptTarget.Latest
+				);
+				expect(isSourceFile(sourceCode)).to.be.true;
+			} catch (error) {
+				console.log(error);
+			}
+		});
+	});
 
-  context("Invalid source code and valid data", () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile("invalidDataset_1", "aws");
-      testData.data = await readJsonData("invalidDataset_1", "aws");
-    });
+	context('Invalid source code and valid data', () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile('invalidDataset_1', 'aws');
+			testData.data = await readJsonData('invalidDataset_1', 'aws');
+		});
 
-    it("Should return a validation Error", async () => {
-      try {
-        await transform(testData.AST, testData.data);
-      } catch (error) {
-        expect(error.message).to.eql("Code is invalid");
-      }
-    });
-  });
+		it('Should return a validation Error', async () => {
+			try {
+				await transform(testData.AST, testData.data);
+			} catch (error) {
+				expect(error.message).to.eql('Code is invalid');
+			}
+		});
+	});
 
-  context("Valid source code and invalid data", () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile("invalidDataset_2", "aws");
-      testData.data = await readJsonData("invalidDataset_2", "aws");
-    });
+	context('Valid source code and invalid data', () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile('invalidDataset_2', 'aws');
+			testData.data = await readJsonData('invalidDataset_2', 'aws');
+		});
 
-    it("Should return a validation Error", async () => {
-      try {
-        await transform(testData.AST, testData.data);
-      } catch (error) {
-        expect(error.message).to.eql("Input is invalid");
-      }
-    });
-  });
+		it('Should return a validation Error', async () => {
+			try {
+				await transform(testData.AST, testData.data);
+			} catch (error) {
+				expect(error.message).to.eql('Input is invalid');
+			}
+		});
+	});
 });

--- a/generator/test/transformers/azure/dummyData/invalidDataset_1/data.json
+++ b/generator/test/transformers/azure/dummyData/invalidDataset_1/data.json
@@ -1,124 +1,124 @@
 {
-  "functions": [
-    {
-      "functionName": "create",
-      "SDKFunctionName": "createOrUpdate",
-      "params": [
-        {
-          "name": "resourceGroupName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "resourceName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "parameters",
-          "optional": false,
-          "type": "TypeReference"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    },
-    {
-      "functionName": "delete",
-      "SDKFunctionName": "deleteMethod",
-      "params": [
-        {
-          "name": "resourceGroupName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "resourceName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    },
-    {
-      "functionName": "updateTags",
-      "SDKFunctionName": "updateTags",
-      "params": [
-        {
-          "name": "resourceGroupName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "resourceName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "parameters",
-          "optional": false,
-          "type": "TypeReference"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    },
-    {
-      "functionName": "listByResourceGroup",
-      "SDKFunctionName": "listByResourceGroup",
-      "params": [
-        {
-          "name": "resourceGroupName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    },
-    {
-      "functionName": "listClusters",
-      "SDKFunctionName": "list",
-      "params": [
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    }
-  ]
+	"functions": [
+		{
+			"functionName": "create",
+			"SDKFunctionName": "createOrUpdate",
+			"params": [
+				{
+					"name": "resourceGroupName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "resourceName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "parameters",
+					"optional": false,
+					"type": "TypeReference"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		},
+		{
+			"functionName": "delete",
+			"SDKFunctionName": "deleteMethod",
+			"params": [
+				{
+					"name": "resourceGroupName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "resourceName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		},
+		{
+			"functionName": "updateTags",
+			"SDKFunctionName": "updateTags",
+			"params": [
+				{
+					"name": "resourceGroupName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "resourceName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "parameters",
+					"optional": false,
+					"type": "TypeReference"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		},
+		{
+			"functionName": "listByResourceGroup",
+			"SDKFunctionName": "listByResourceGroup",
+			"params": [
+				{
+					"name": "resourceGroupName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		},
+		{
+			"functionName": "listClusters",
+			"SDKFunctionName": "list",
+			"params": [
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		}
+	]
 }

--- a/generator/test/transformers/azure/dummyData/validDataset/data.json
+++ b/generator/test/transformers/azure/dummyData/validDataset/data.json
@@ -1,124 +1,124 @@
 {
-  "functions": [
-    {
-      "functionName": "create",
-      "SDKFunctionName": "createOrUpdate",
-      "params": [
-        {
-          "name": "resourceGroupName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "resourceName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "parameters",
-          "optional": false,
-          "type": "TypeReference"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    },
-    {
-      "functionName": "delete",
-      "SDKFunctionName": "deleteMethod",
-      "params": [
-        {
-          "name": "resourceGroupName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "resourceName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    },
-    {
-      "functionName": "updateTags",
-      "SDKFunctionName": "updateTags",
-      "params": [
-        {
-          "name": "resourceGroupName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "resourceName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "parameters",
-          "optional": false,
-          "type": "TypeReference"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    },
-    {
-      "functionName": "listByResourceGroup",
-      "SDKFunctionName": "listByResourceGroup",
-      "params": [
-        {
-          "name": "resourceGroupName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    },
-    {
-      "functionName": "listClusters",
-      "SDKFunctionName": "list",
-      "params": [
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    }
-  ]
+	"functions": [
+		{
+			"functionName": "create",
+			"SDKFunctionName": "createOrUpdate",
+			"params": [
+				{
+					"name": "resourceGroupName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "resourceName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "parameters",
+					"optional": false,
+					"type": "TypeReference"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		},
+		{
+			"functionName": "delete",
+			"SDKFunctionName": "deleteMethod",
+			"params": [
+				{
+					"name": "resourceGroupName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "resourceName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		},
+		{
+			"functionName": "updateTags",
+			"SDKFunctionName": "updateTags",
+			"params": [
+				{
+					"name": "resourceGroupName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "resourceName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "parameters",
+					"optional": false,
+					"type": "TypeReference"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		},
+		{
+			"functionName": "listByResourceGroup",
+			"SDKFunctionName": "listByResourceGroup",
+			"params": [
+				{
+					"name": "resourceGroupName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		},
+		{
+			"functionName": "listClusters",
+			"SDKFunctionName": "list",
+			"params": [
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		}
+	]
 }

--- a/generator/test/transformers/azure/transformer.test.ts
+++ b/generator/test/transformers/azure/transformer.test.ts
@@ -1,71 +1,71 @@
-import { expect } from "chai";
-import { createSourceFile, isSourceFile,ScriptTarget } from "typescript";
+import { expect } from 'chai';
+import { createSourceFile, isSourceFile, ScriptTarget } from 'typescript';
 
-import { transform } from "../../../transformers/azure/transformer";
-import { readJsonData, readSourceFile } from "../lib/helper";
+import { transform } from '../../../transformers/azure/transformer';
+import { readJsonData, readSourceFile } from '../lib/helper';
 
 interface TestData {
-  AST: any;
-  data: any;
+	AST: any;
+	data: any;
 }
 
-describe("Azure transformer transform", () => {
-  context("Valid source code and valid data", () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile("validDataset", "azure");
-      testData.data = await readJsonData("validDataset", "azure");
-    });
+describe('Azure transformer transform', () => {
+	context('Valid source code and valid data', () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile('validDataset', 'azure');
+			testData.data = await readJsonData('validDataset', 'azure');
+		});
 
-    it("Should return a String", async () => {
-      const result = await transform(testData.AST, testData.data);
-      expect(result).to.be.string;
-    });
+		it('Should return a String', async () => {
+			const result = await transform(testData.AST, testData.data);
+			expect(result).to.be.string;
+		});
 
-    it("Should return a Javascript code in String format", async () => {
-      const result = await transform(testData.AST, testData.data);
-      try {
-        const sourceCode = createSourceFile(
-          "someClass.js",
-          result,
-          ScriptTarget.Latest
-        );
-        expect(isSourceFile(sourceCode)).to.be.true;
-      } catch (error) {
-        console.log(error);
-      }
-    });
-  });
+		it('Should return a Javascript code in String format', async () => {
+			const result = await transform(testData.AST, testData.data);
+			try {
+				const sourceCode = createSourceFile(
+					'someClass.js',
+					result,
+					ScriptTarget.Latest
+				);
+				expect(isSourceFile(sourceCode)).to.be.true;
+			} catch (error) {
+				console.log(error);
+			}
+		});
+	});
 
-  context("Invalid source code and valid data", () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile("invalidDataset_1", "azure");
-      testData.data = await readJsonData("invalidDataset_1", "azure");
-    });
+	context('Invalid source code and valid data', () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile('invalidDataset_1', 'azure');
+			testData.data = await readJsonData('invalidDataset_1', 'azure');
+		});
 
-    it("Should return a validation Error", async () => {
-      try {
-        await transform(testData.AST, testData.data);
-      } catch (error) {
-        expect(error.message).to.eql("Code is invalid");
-      }
-    });
-  });
+		it('Should return a validation Error', async () => {
+			try {
+				await transform(testData.AST, testData.data);
+			} catch (error) {
+				expect(error.message).to.eql('Code is invalid');
+			}
+		});
+	});
 
-  context("Valid source code and invalid data", () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile("invalidDataset_2", "azure");
-      testData.data = await readJsonData("invalidDataset_2", "azure");
-    });
+	context('Valid source code and invalid data', () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile('invalidDataset_2', 'azure');
+			testData.data = await readJsonData('invalidDataset_2', 'azure');
+		});
 
-    it("Should return a validation Error", async () => {
-      try {
-        await transform(testData.AST, testData.data);
-      } catch (error) {
-        expect(error.message).to.eql("Input is invalid");
-      }
-    });
-  });
+		it('Should return a validation Error', async () => {
+			try {
+				await transform(testData.AST, testData.data);
+			} catch (error) {
+				expect(error.message).to.eql('Input is invalid');
+			}
+		});
+	});
 });

--- a/generator/test/transformers/do/dummyData/invalidDataset_1/data.json
+++ b/generator/test/transformers/do/dummyData/invalidDataset_1/data.json
@@ -1,102 +1,102 @@
 {
-  "className": "Kubernetes",
-  "functions": [
-    {
-      "functionName": "listClusters",
-      "SDKFunctionName": "getClusters",
-      "params": [
-        {
-          "name": "includeAll",
-          "optional": true,
-          "type": "BooleanKeyword",
-          "typeName": null
-        },
-        {
-          "name": "page",
-          "optional": true,
-          "type": "NumberKeyword",
-          "typeName": null
-        },
-        {
-          "name": "pageSize",
-          "optional": true,
-          "type": "NumberKeyword",
-          "typeName": null
-        }
-      ]
-    },
-    {
-      "functionName": "create",
-      "SDKFunctionName": "create",
-      "params": [
-        {
-          "name": "options",
-          "optional": false,
-          "type": "TypeReference",
-          "typeName": "NewClusterRequest"
-        }
-      ]
-    },
-    {
-      "functionName": "delete",
-      "SDKFunctionName": "delete",
-      "params": [
-        {
-          "name": "clusterId",
-          "optional": false,
-          "type": "StringKeyword",
-          "typeName": null
-        }
-      ]
-    },
-    {
-      "functionName": "listNodegroups",
-      "SDKFunctionName": "getNodePools",
-      "params": [
-        {
-          "name": "clusterId",
-          "optional": false,
-          "type": "StringKeyword",
-          "typeName": null
-        },
-        {
-          "name": "includeAll",
-          "optional": true,
-          "type": "BooleanKeyword",
-          "typeName": null
-        },
-        {
-          "name": "page",
-          "optional": true,
-          "type": "NumberKeyword",
-          "typeName": null
-        },
-        {
-          "name": "pageSize",
-          "optional": true,
-          "type": "NumberKeyword",
-          "typeName": null
-        }
-      ]
-    },
-    {
-      "functionName": "createNodeGroup",
-      "SDKFunctionName": "addNodePool",
-      "params": [
-        {
-          "name": "clusterId",
-          "optional": false,
-          "type": "StringKeyword",
-          "typeName": null
-        },
-        {
-          "name": "nodePool",
-          "optional": false,
-          "type": "TypeReference",
-          "typeName": "ClusterNodePool"
-        }
-      ]
-    }
-  ],
-  "serviceName": "Kubernetes"
+	"className": "Kubernetes",
+	"functions": [
+		{
+			"functionName": "listClusters",
+			"SDKFunctionName": "getClusters",
+			"params": [
+				{
+					"name": "includeAll",
+					"optional": true,
+					"type": "BooleanKeyword",
+					"typeName": null
+				},
+				{
+					"name": "page",
+					"optional": true,
+					"type": "NumberKeyword",
+					"typeName": null
+				},
+				{
+					"name": "pageSize",
+					"optional": true,
+					"type": "NumberKeyword",
+					"typeName": null
+				}
+			]
+		},
+		{
+			"functionName": "create",
+			"SDKFunctionName": "create",
+			"params": [
+				{
+					"name": "options",
+					"optional": false,
+					"type": "TypeReference",
+					"typeName": "NewClusterRequest"
+				}
+			]
+		},
+		{
+			"functionName": "delete",
+			"SDKFunctionName": "delete",
+			"params": [
+				{
+					"name": "clusterId",
+					"optional": false,
+					"type": "StringKeyword",
+					"typeName": null
+				}
+			]
+		},
+		{
+			"functionName": "listNodegroups",
+			"SDKFunctionName": "getNodePools",
+			"params": [
+				{
+					"name": "clusterId",
+					"optional": false,
+					"type": "StringKeyword",
+					"typeName": null
+				},
+				{
+					"name": "includeAll",
+					"optional": true,
+					"type": "BooleanKeyword",
+					"typeName": null
+				},
+				{
+					"name": "page",
+					"optional": true,
+					"type": "NumberKeyword",
+					"typeName": null
+				},
+				{
+					"name": "pageSize",
+					"optional": true,
+					"type": "NumberKeyword",
+					"typeName": null
+				}
+			]
+		},
+		{
+			"functionName": "createNodeGroup",
+			"SDKFunctionName": "addNodePool",
+			"params": [
+				{
+					"name": "clusterId",
+					"optional": false,
+					"type": "StringKeyword",
+					"typeName": null
+				},
+				{
+					"name": "nodePool",
+					"optional": false,
+					"type": "TypeReference",
+					"typeName": "ClusterNodePool"
+				}
+			]
+		}
+	],
+	"serviceName": "Kubernetes"
 }

--- a/generator/test/transformers/do/dummyData/invalidDataset_2/data.json
+++ b/generator/test/transformers/do/dummyData/invalidDataset_2/data.json
@@ -1,15 +1,15 @@
 {
-  "functions": [
-    {
-      "SDKFunctionName": "getClusters",
-      "params": [
-        {
-          "name": "includeAll",
-          "optional": false,
-          "type": "TypeReference",
-          "invalid": true
-        }
-      ]
-    }
-  ]
+	"functions": [
+		{
+			"SDKFunctionName": "getClusters",
+			"params": [
+				{
+					"name": "includeAll",
+					"optional": false,
+					"type": "TypeReference",
+					"invalid": true
+				}
+			]
+		}
+	]
 }

--- a/generator/test/transformers/do/dummyData/validDataset/data.json
+++ b/generator/test/transformers/do/dummyData/validDataset/data.json
@@ -1,102 +1,102 @@
 {
-  "className": "Kubernetes",
-  "functions": [
-    {
-      "functionName": "listClusters",
-      "SDKFunctionName": "getClusters",
-      "params": [
-        {
-          "name": "includeAll",
-          "optional": true,
-          "type": "BooleanKeyword",
-          "typeName": null
-        },
-        {
-          "name": "page",
-          "optional": true,
-          "type": "NumberKeyword",
-          "typeName": null
-        },
-        {
-          "name": "pageSize",
-          "optional": true,
-          "type": "NumberKeyword",
-          "typeName": null
-        }
-      ]
-    },
-    {
-      "functionName": "create",
-      "SDKFunctionName": "create",
-      "params": [
-        {
-          "name": "options",
-          "optional": false,
-          "type": "TypeReference",
-          "typeName": "NewClusterRequest"
-        }
-      ]
-    },
-    {
-      "functionName": "delete",
-      "SDKFunctionName": "delete",
-      "params": [
-        {
-          "name": "clusterId",
-          "optional": false,
-          "type": "StringKeyword",
-          "typeName": null
-        }
-      ]
-    },
-    {
-      "functionName": "listNodegroups",
-      "SDKFunctionName": "getNodePools",
-      "params": [
-        {
-          "name": "clusterId",
-          "optional": false,
-          "type": "StringKeyword",
-          "typeName": null
-        },
-        {
-          "name": "includeAll",
-          "optional": true,
-          "type": "BooleanKeyword",
-          "typeName": null
-        },
-        {
-          "name": "page",
-          "optional": true,
-          "type": "NumberKeyword",
-          "typeName": null
-        },
-        {
-          "name": "pageSize",
-          "optional": true,
-          "type": "NumberKeyword",
-          "typeName": null
-        }
-      ]
-    },
-    {
-      "functionName": "createNodeGroup",
-      "SDKFunctionName": "addNodePool",
-      "params": [
-        {
-          "name": "clusterId",
-          "optional": false,
-          "type": "StringKeyword",
-          "typeName": null
-        },
-        {
-          "name": "nodePool",
-          "optional": false,
-          "type": "TypeReference",
-          "typeName": "ClusterNodePool"
-        }
-      ]
-    }
-  ],
-  "serviceName": "Kubernetes"
+	"className": "Kubernetes",
+	"functions": [
+		{
+			"functionName": "listClusters",
+			"SDKFunctionName": "getClusters",
+			"params": [
+				{
+					"name": "includeAll",
+					"optional": true,
+					"type": "BooleanKeyword",
+					"typeName": null
+				},
+				{
+					"name": "page",
+					"optional": true,
+					"type": "NumberKeyword",
+					"typeName": null
+				},
+				{
+					"name": "pageSize",
+					"optional": true,
+					"type": "NumberKeyword",
+					"typeName": null
+				}
+			]
+		},
+		{
+			"functionName": "create",
+			"SDKFunctionName": "create",
+			"params": [
+				{
+					"name": "options",
+					"optional": false,
+					"type": "TypeReference",
+					"typeName": "NewClusterRequest"
+				}
+			]
+		},
+		{
+			"functionName": "delete",
+			"SDKFunctionName": "delete",
+			"params": [
+				{
+					"name": "clusterId",
+					"optional": false,
+					"type": "StringKeyword",
+					"typeName": null
+				}
+			]
+		},
+		{
+			"functionName": "listNodegroups",
+			"SDKFunctionName": "getNodePools",
+			"params": [
+				{
+					"name": "clusterId",
+					"optional": false,
+					"type": "StringKeyword",
+					"typeName": null
+				},
+				{
+					"name": "includeAll",
+					"optional": true,
+					"type": "BooleanKeyword",
+					"typeName": null
+				},
+				{
+					"name": "page",
+					"optional": true,
+					"type": "NumberKeyword",
+					"typeName": null
+				},
+				{
+					"name": "pageSize",
+					"optional": true,
+					"type": "NumberKeyword",
+					"typeName": null
+				}
+			]
+		},
+		{
+			"functionName": "createNodeGroup",
+			"SDKFunctionName": "addNodePool",
+			"params": [
+				{
+					"name": "clusterId",
+					"optional": false,
+					"type": "StringKeyword",
+					"typeName": null
+				},
+				{
+					"name": "nodePool",
+					"optional": false,
+					"type": "TypeReference",
+					"typeName": "ClusterNodePool"
+				}
+			]
+		}
+	],
+	"serviceName": "Kubernetes"
 }

--- a/generator/test/transformers/do/transformer.test.ts
+++ b/generator/test/transformers/do/transformer.test.ts
@@ -1,71 +1,71 @@
-import { expect } from "chai";
-import { createSourceFile, isSourceFile,ScriptTarget } from "typescript";
+import { expect } from 'chai';
+import { createSourceFile, isSourceFile, ScriptTarget } from 'typescript';
 
-import { transform } from "../../../transformers/do/transformer";
-import { readJsonData, readSourceFile } from "../lib/helper";
+import { transform } from '../../../transformers/do/transformer';
+import { readJsonData, readSourceFile } from '../lib/helper';
 
 interface TestData {
-  AST: any;
-  data: any;
+	AST: any;
+	data: any;
 }
 
-describe("Digital Ocean transformer transform", () => {
-  context("Valid source code and valid data", () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile("validDataset", "do");
-      testData.data = await readJsonData("validDataset", "do");
-    });
+describe('Digital Ocean transformer transform', () => {
+	context('Valid source code and valid data', () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile('validDataset', 'do');
+			testData.data = await readJsonData('validDataset', 'do');
+		});
 
-    it("Should return a String", async () => {
-      const result = await transform(testData.AST, testData.data);
-      expect(result).to.be.string;
-    });
+		it('Should return a String', async () => {
+			const result = await transform(testData.AST, testData.data);
+			expect(result).to.be.string;
+		});
 
-    it("Should return a Javascript code in String format", async () => {
-      const result = await transform(testData.AST, testData.data);
-      try {
-        const sourceCode = createSourceFile(
-          "someClass.js",
-          result,
-          ScriptTarget.Latest
-        );
-        expect(isSourceFile(sourceCode)).to.be.true;
-      } catch (error) {
-        console.log(error);
-      }
-    });
-  });
+		it('Should return a Javascript code in String format', async () => {
+			const result = await transform(testData.AST, testData.data);
+			try {
+				const sourceCode = createSourceFile(
+					'someClass.js',
+					result,
+					ScriptTarget.Latest
+				);
+				expect(isSourceFile(sourceCode)).to.be.true;
+			} catch (error) {
+				console.log(error);
+			}
+		});
+	});
 
-  context("Invalid source code and valid data", () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile("invalidDataset_1", "do");
-      testData.data = await readJsonData("invalidDataset_1", "do");
-    });
+	context('Invalid source code and valid data', () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile('invalidDataset_1', 'do');
+			testData.data = await readJsonData('invalidDataset_1', 'do');
+		});
 
-    it("Should return a validation Error", async () => {
-      try {
-        await transform(testData.AST, testData.data);
-      } catch (error) {
-        expect(error.message).to.eql("Code is invalid");
-      }
-    });
-  });
+		it('Should return a validation Error', async () => {
+			try {
+				await transform(testData.AST, testData.data);
+			} catch (error) {
+				expect(error.message).to.eql('Code is invalid');
+			}
+		});
+	});
 
-  context("Valid source code and invalid data", () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile("invalidDataset_2", "do");
-      testData.data = await readJsonData("invalidDataset_2", "do");
-    });
+	context('Valid source code and invalid data', () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile('invalidDataset_2', 'do');
+			testData.data = await readJsonData('invalidDataset_2', 'do');
+		});
 
-    it("Should return a validation Error", async () => {
-      try {
-        await transform(testData.AST, testData.data);
-      } catch (error) {
-        expect(error.message).to.eql("Input is invalid");
-      }
-    });
-  });
+		it('Should return a validation Error', async () => {
+			try {
+				await transform(testData.AST, testData.data);
+			} catch (error) {
+				expect(error.message).to.eql('Input is invalid');
+			}
+		});
+	});
 });

--- a/generator/test/transformers/googleCloud/classBasedTransformer.test.ts
+++ b/generator/test/transformers/googleCloud/classBasedTransformer.test.ts
@@ -1,89 +1,95 @@
-import { expect } from "chai";
-import { createSourceFile, isSourceFile,ScriptTarget } from "typescript";
+import { expect } from 'chai';
+import { createSourceFile, isSourceFile, ScriptTarget } from 'typescript';
 
-import { classBasedTransform } from "../../../transformers/googleCloud/classBasedTransformer";
-import { readJsonData, readSourceFile } from "../lib/helper";
+import { classBasedTransform } from '../../../transformers/googleCloud/classBasedTransformer';
+import { readJsonData, readSourceFile } from '../lib/helper';
 
 interface TestData {
-  AST: any;
-  data: any;
+	AST: any;
+	data: any;
 }
 
-describe("Google Cloud transformer classBasedTransform", () => {
-  context("Valid source code and valid data", () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile(
-        "classBasedTransformer/validDataset",
-        "googleCloud"
-      );
-      testData.data = await readJsonData(
-        "classBasedTransformer/validDataset",
-        "googleCloud"
-      );
-    });
+describe('Google Cloud transformer classBasedTransform', () => {
+	context('Valid source code and valid data', () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile(
+				'classBasedTransformer/validDataset',
+				'googleCloud'
+			);
+			testData.data = await readJsonData(
+				'classBasedTransformer/validDataset',
+				'googleCloud'
+			);
+		});
 
-    it("Should return a String", async () => {
-      const result = await classBasedTransform(testData.AST, testData.data);
-      expect(result).to.be.string;
-    });
+		it('Should return a String', async () => {
+			const result = await classBasedTransform(
+				testData.AST,
+				testData.data
+			);
+			expect(result).to.be.string;
+		});
 
-    it("Should return a Javascript code in String format", async () => {
-      const result = await classBasedTransform(testData.AST, testData.data);
-      try {
-        const sourceCode = createSourceFile(
-          "someClass.js",
-          result,
-          ScriptTarget.Latest
-        );
-        expect(isSourceFile(sourceCode)).to.be.true;
-      } catch (error) {
-        console.log(error);
-      }
-    });
-  });
+		it('Should return a Javascript code in String format', async () => {
+			const result = await classBasedTransform(
+				testData.AST,
+				testData.data
+			);
+			try {
+				const sourceCode = createSourceFile(
+					'someClass.js',
+					result,
+					ScriptTarget.Latest
+				);
+				expect(isSourceFile(sourceCode)).to.be.true;
+			} catch (error) {
+				console.log(error);
+			}
+		});
+	});
 
-  context("Invalid source code and valid data", () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile(
-        "classBasedTransformer/invalidDataset_1",
-        "googleCloud"
-      );
-      testData.data = await readJsonData(
-        "classBasedTransformer/invalidDataset_1",
-        "googleCloud"
-      );
-    });
+	context('Invalid source code and valid data', () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile(
+				'classBasedTransformer/invalidDataset_1',
+				'googleCloud'
+			);
+			testData.data = await readJsonData(
+				'classBasedTransformer/invalidDataset_1',
+				'googleCloud'
+			);
+		});
 
-    it("Should return a validation Error", async () => {
-      try {
-        await classBasedTransform(testData.AST, testData.data);
-      } catch (error) {
-        expect(error.message).to.eql("Code is invalid");
-      }
-    });
-  });
+		it('Should return a validation Error', async () => {
+			try {
+				await classBasedTransform(testData.AST, testData.data);
+			} catch (error) {
+				expect(error.message).to.eql('Code is invalid');
+			}
+		});
+	});
 
-  context("Valid source code and invalid data", async () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile(
-        "classBasedTransformer/invalidDataset_2",
-        "googleCloud"
-      );
-      testData.data = await readJsonData(
-        "classBasedTransformer/invalidDataset_2",
-        "googleCloud"
-      );
-    });
+	context('Valid source code and invalid data', async () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile(
+				'classBasedTransformer/invalidDataset_2',
+				'googleCloud'
+			);
+			testData.data = await readJsonData(
+				'classBasedTransformer/invalidDataset_2',
+				'googleCloud'
+			);
+		});
 
-    it("Should return a validation Error", async () => {
-      try {
-        await classBasedTransform(testData.AST, testData.data);
-      } catch (error) {
-        expect(error.message).to.eql("Input is invalid");
-      }
-    });
-  });
+		it('Should return a validation Error', async () => {
+			try {
+				await classBasedTransform(testData.AST, testData.data);
+			} catch (error) {
+				expect(error.message).to.eql('Input is invalid');
+			}
+		});
+	});
 });

--- a/generator/test/transformers/googleCloud/clientBasedTransformer.test.ts
+++ b/generator/test/transformers/googleCloud/clientBasedTransformer.test.ts
@@ -1,89 +1,95 @@
-import { expect } from "chai";
-import { createSourceFile, isSourceFile,ScriptTarget } from "typescript";
+import { expect } from 'chai';
+import { createSourceFile, isSourceFile, ScriptTarget } from 'typescript';
 
-import { clientBasedTransform } from "../../../transformers/googleCloud/clientBasedTransformer";
-import { readJsonData, readSourceFile } from "../lib/helper";
+import { clientBasedTransform } from '../../../transformers/googleCloud/clientBasedTransformer';
+import { readJsonData, readSourceFile } from '../lib/helper';
 
 interface TestData {
-  AST: any;
-  data: any;
+	AST: any;
+	data: any;
 }
 
-describe("Google Cloud transformer clientBasedTransform", () => {
-  context("Valid source code and valid data", () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile(
-        "clientBasedTransformer/validDataset",
-        "googleCloud"
-      );
-      testData.data = await readJsonData(
-        "clientBasedTransformer/validDataset",
-        "googleCloud"
-      );
-    });
+describe('Google Cloud transformer clientBasedTransform', () => {
+	context('Valid source code and valid data', () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile(
+				'clientBasedTransformer/validDataset',
+				'googleCloud'
+			);
+			testData.data = await readJsonData(
+				'clientBasedTransformer/validDataset',
+				'googleCloud'
+			);
+		});
 
-    it("Should return a String", async () => {
-      const result = await clientBasedTransform(testData.AST, testData.data);
-      expect(result).to.be.string;
-    });
+		it('Should return a String', async () => {
+			const result = await clientBasedTransform(
+				testData.AST,
+				testData.data
+			);
+			expect(result).to.be.string;
+		});
 
-    it("Should return a Javascript code in String format", async () => {
-      const result = await clientBasedTransform(testData.AST, testData.data);
-      try {
-        const sourceCode = createSourceFile(
-          "someClass.js",
-          result,
-          ScriptTarget.Latest
-        );
-        expect(isSourceFile(sourceCode)).to.be.true;
-      } catch (error) {
-        console.log(error);
-      }
-    });
-  });
+		it('Should return a Javascript code in String format', async () => {
+			const result = await clientBasedTransform(
+				testData.AST,
+				testData.data
+			);
+			try {
+				const sourceCode = createSourceFile(
+					'someClass.js',
+					result,
+					ScriptTarget.Latest
+				);
+				expect(isSourceFile(sourceCode)).to.be.true;
+			} catch (error) {
+				console.log(error);
+			}
+		});
+	});
 
-  context("Invalid source code and valid data", () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile(
-        "clientBasedTransformer/invalidDataset_1",
-        "googleCloud"
-      );
-      testData.data = await readJsonData(
-        "clientBasedTransformer/invalidDataset_1",
-        "googleCloud"
-      );
-    });
+	context('Invalid source code and valid data', () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile(
+				'clientBasedTransformer/invalidDataset_1',
+				'googleCloud'
+			);
+			testData.data = await readJsonData(
+				'clientBasedTransformer/invalidDataset_1',
+				'googleCloud'
+			);
+		});
 
-    it("Should return a validation Error", async () => {
-      try {
-        await clientBasedTransform(testData.AST, testData.data);
-      } catch (error) {
-        expect(error.message).to.eql("Code is invalid");
-      }
-    });
-  });
+		it('Should return a validation Error', async () => {
+			try {
+				await clientBasedTransform(testData.AST, testData.data);
+			} catch (error) {
+				expect(error.message).to.eql('Code is invalid');
+			}
+		});
+	});
 
-  context("Valid source code and invalid data", () => {
-    const testData: TestData = { AST: null, data: null };
-    before(async () => {
-      testData.AST = await readSourceFile(
-        "clientBasedTransformer/invalidDataset_2",
-        "googleCloud"
-      );
-      testData.data = await readJsonData(
-        "clientBasedTransformer/invalidDataset_2",
-        "googleCloud"
-      );
-    });
+	context('Valid source code and invalid data', () => {
+		const testData: TestData = { AST: null, data: null };
+		before(async () => {
+			testData.AST = await readSourceFile(
+				'clientBasedTransformer/invalidDataset_2',
+				'googleCloud'
+			);
+			testData.data = await readJsonData(
+				'clientBasedTransformer/invalidDataset_2',
+				'googleCloud'
+			);
+		});
 
-    it("Should return a validation Error", async () => {
-      try {
-        await clientBasedTransform(testData.AST, testData.data);
-      } catch (error) {
-        expect(error.message).to.eql("Input is invalid");
-      }
-    });
-  });
+		it('Should return a validation Error', async () => {
+			try {
+				await clientBasedTransform(testData.AST, testData.data);
+			} catch (error) {
+				expect(error.message).to.eql('Input is invalid');
+			}
+		});
+	});
 });

--- a/generator/test/transformers/googleCloud/dummyData/classBasedTransformer/invalidDataset_1/data.json
+++ b/generator/test/transformers/googleCloud/dummyData/classBasedTransformer/invalidDataset_1/data.json
@@ -1,3997 +1,3997 @@
 {
-  "mainClass": "Storage",
-  "functions": [
-    {
-      "functionName": "makePublic",
-      "SDKFunctionName": "makePublic",
-      "params": [],
-      "pkgName": "storage",
-      "fileName": "file.d.ts",
-      "client": "File",
-      "returnType": "TypeReference",
-      "returnTypeName": "Promise",
-      "classConstructorData": {
-        "parameters": [
-          {
-            "name": "bucket",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "Bucket"
-          },
-          {
-            "name": "name",
-            "optional": false,
-            "type": "StringKeyword",
-            "typeRefName": null
-          },
-          {
-            "name": "options",
-            "optional": true,
-            "type": "TypeReference",
-            "typeRefName": "FileOptions"
-          }
-        ]
-      }
-    }
-  ],
-  "classData": [
-    {
-      "name": "AclRoleAccessorMethods",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "_assignAccessMethods",
-          "params": [
-            {
-              "name": "role",
-              "optional": false,
-              "type": "StringKeyword"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "AclRoleAccessorMethods"
-        }
-      ],
-      "properties": [
-        {
-          "name": "owners",
-          "type": "TypeLiteral",
-          "typeRefName": null
-        },
-        {
-          "name": "readers",
-          "type": "TypeLiteral",
-          "typeRefName": null
-        },
-        {
-          "name": "writers",
-          "type": "TypeLiteral",
-          "typeRefName": null
-        }
-      ],
-      "constructor": {
-        "parameters": []
-      }
-    },
-    {
-      "name": "Acl",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "add",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "add",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "delete",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "delete",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "get",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "get",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "get",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "update",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "update",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makeAclObject_",
-          "params": [
-            {
-              "name": "accessControlObject",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "AccessControlObject",
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "request",
-          "params": [
-            {
-              "name": "reqOpts",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Acl"
-        }
-      ],
-      "properties": [
-        {
-          "name": "default",
-          "type": "TypeReference",
-          "typeRefName": "Acl"
-        },
-        {
-          "name": "pathPrefix",
-          "type": "StringKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "request_",
-          "type": "FunctionType",
-          "typeRefName": null
-        }
-      ],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "options",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "AclOptions"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Bucket",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "addLifecycleRule",
-          "params": [
-            {
-              "name": "rule",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "addLifecycleRule",
-          "params": [
-            {
-              "name": "rule",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "addLifecycleRule",
-          "params": [
-            {
-              "name": "rule",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "combine",
-          "params": [
-            {
-              "name": "sources",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "combine",
-          "params": [
-            {
-              "name": "sources",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "combine",
-          "params": [
-            {
-              "name": "sources",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createChannel",
-          "params": [
-            {
-              "name": "id",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "config",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createChannel",
-          "params": [
-            {
-              "name": "id",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "config",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createChannel",
-          "params": [
-            {
-              "name": "id",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "config",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createNotification",
-          "params": [
-            {
-              "name": "topic",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createNotification",
-          "params": [
-            {
-              "name": "topic",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createNotification",
-          "params": [
-            {
-              "name": "topic",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "deleteFiles",
-          "params": [
-            {
-              "name": "query",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "deleteFiles",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "deleteFiles",
-          "params": [
-            {
-              "name": "query",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "deleteLabels",
-          "params": [
-            {
-              "name": "labels",
-              "optional": true,
-              "type": "UnionType"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "deleteLabels",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "deleteLabels",
-          "params": [
-            {
-              "name": "labels",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "disableRequesterPays",
-          "params": [],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "disableRequesterPays",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "enableLogging",
-          "params": [
-            {
-              "name": "config",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "enableLogging",
-          "params": [
-            {
-              "name": "config",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "enableRequesterPays",
-          "params": [],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "enableRequesterPays",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "file",
-          "params": [
-            {
-              "name": "name",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "File",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getFiles",
-          "params": [
-            {
-              "name": "query",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getFiles",
-          "params": [
-            {
-              "name": "query",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getFiles",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getLabels",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getLabels",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getLabels",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getNotifications",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getNotifications",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getNotifications",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedUrl",
-          "params": [
-            {
-              "name": "cfg",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedUrl",
-          "params": [
-            {
-              "name": "cfg",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "lock",
-          "params": [
-            {
-              "name": "metageneration",
-              "optional": false,
-              "type": "UnionType"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "lock",
-          "params": [
-            {
-              "name": "metageneration",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePrivate",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePrivate",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePrivate",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePublic",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePublic",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePublic",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "notification",
-          "params": [
-            {
-              "name": "id",
-              "optional": false,
-              "type": "StringKeyword"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Notification",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "removeRetentionPeriod",
-          "params": [],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "removeRetentionPeriod",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "request",
-          "params": [
-            {
-              "name": "reqOpts",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "request",
-          "params": [
-            {
-              "name": "reqOpts",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setLabels",
-          "params": [
-            {
-              "name": "labels",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setLabels",
-          "params": [
-            {
-              "name": "labels",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setLabels",
-          "params": [
-            {
-              "name": "labels",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setRetentionPeriod",
-          "params": [
-            {
-              "name": "duration",
-              "optional": false,
-              "type": "NumberKeyword"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setRetentionPeriod",
-          "params": [
-            {
-              "name": "duration",
-              "optional": false,
-              "type": "NumberKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setCorsConfiguration",
-          "params": [
-            {
-              "name": "corsConfiguration",
-              "optional": false,
-              "type": "ArrayType"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setCorsConfiguration",
-          "params": [
-            {
-              "name": "corsConfiguration",
-              "optional": false,
-              "type": "ArrayType"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setStorageClass",
-          "params": [
-            {
-              "name": "storageClass",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setStorageClass",
-          "params": [
-            {
-              "name": "storageClass",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setStorageClass",
-          "params": [
-            {
-              "name": "storageClass",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setUserProject",
-          "params": [
-            {
-              "name": "userProject",
-              "optional": false,
-              "type": "StringKeyword"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "upload",
-          "params": [
-            {
-              "name": "pathString",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "upload",
-          "params": [
-            {
-              "name": "pathString",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "upload",
-          "params": [
-            {
-              "name": "pathString",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makeAllFilesPublicPrivate_",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makeAllFilesPublicPrivate_",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makeAllFilesPublicPrivate_",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getId",
-          "params": [],
-          "returnType": "StringKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        }
-      ],
-      "properties": [
-        {
-          "name": "name",
-          "type": "StringKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "storage",
-          "type": "TypeReference",
-          "typeRefName": "Storage"
-        },
-        {
-          "name": "userProject",
-          "type": "StringKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "acl",
-          "type": "TypeReference",
-          "typeRefName": "Acl"
-        },
-        {
-          "name": "iam",
-          "type": "TypeReference",
-          "typeRefName": "Iam"
-        },
-        {
-          "name": "getFilesStream",
-          "type": "TypeReference",
-          "typeRefName": "Function"
-        },
-        {
-          "name": "signer",
-          "type": "TypeReference",
-          "typeRefName": "URLSigner"
-        }
-      ],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "storage",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "Storage"
-          },
-          {
-            "name": "name",
-            "optional": false,
-            "type": "StringKeyword",
-            "typeRefName": null
-          },
-          {
-            "name": "options",
-            "optional": true,
-            "type": "TypeReference",
-            "typeRefName": "BucketOptions"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Channel",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "channel.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "stop",
-          "params": [],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Channel"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "channel.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "stop",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Channel"
-        }
-      ],
-      "properties": [],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "storage",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "Storage"
-          },
-          {
-            "name": "id",
-            "optional": false,
-            "type": "StringKeyword",
-            "typeRefName": null
-          },
-          {
-            "name": "resourceId",
-            "optional": false,
-            "type": "StringKeyword",
-            "typeRefName": null
-          }
-        ]
-      }
-    },
-    {
-      "name": "RequestError",
-      "methods": [],
-      "properties": [
-        {
-          "name": "code",
-          "type": "StringKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "errors",
-          "type": "ArrayType",
-          "typeRefName": null
-        }
-      ],
-      "constructor": null
-    },
-    {
-      "name": "File",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "copy",
-          "params": [
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "copy",
-          "params": [
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "copy",
-          "params": [
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createReadStream",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Readable",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createResumableUpload",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createResumableUpload",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createResumableUpload",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createWriteStream",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Writable",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "deleteResumableCache",
-          "params": [],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "download",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "download",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "download",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setEncryptionKey",
-          "params": [
-            {
-              "name": "encryptionKey",
-              "optional": false,
-              "type": "UnionType"
-            }
-          ],
-          "returnType": "ThisType",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getExpirationDate",
-          "params": [],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getExpirationDate",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedPolicy",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedPolicy",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedPolicy",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "generateSignedPostPolicyV2",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "generateSignedPostPolicyV2",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "generateSignedPostPolicyV2",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "generateSignedPostPolicyV4",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "generateSignedPostPolicyV4",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "generateSignedPostPolicyV4",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedUrl",
-          "params": [
-            {
-              "name": "cfg",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedUrl",
-          "params": [
-            {
-              "name": "cfg",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "isPublic",
-          "params": [],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "isPublic",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePrivate",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePrivate",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePrivate",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": "makePublic",
-          "SDKFunctionName": "makePublic",
-          "params": [],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File",
-          "classConstructorData": {
-            "parameters": [
-              {
-                "name": "bucket",
-                "optional": false,
-                "type": "TypeReference",
-                "typeRefName": "Bucket"
-              },
-              {
-                "name": "name",
-                "optional": false,
-                "type": "StringKeyword",
-                "typeRefName": null
-              },
-              {
-                "name": "options",
-                "optional": true,
-                "type": "TypeReference",
-                "typeRefName": "FileOptions"
-              }
-            ]
-          }
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": "makePublic",
-          "SDKFunctionName": "makePublic",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File",
-          "classConstructorData": {
-            "parameters": [
-              {
-                "name": "bucket",
-                "optional": false,
-                "type": "TypeReference",
-                "typeRefName": "Bucket"
-              },
-              {
-                "name": "name",
-                "optional": false,
-                "type": "StringKeyword",
-                "typeRefName": null
-              },
-              {
-                "name": "options",
-                "optional": true,
-                "type": "TypeReference",
-                "typeRefName": "FileOptions"
-              }
-            ]
-          }
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "move",
-          "params": [
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "move",
-          "params": [
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "move",
-          "params": [
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "request",
-          "params": [
-            {
-              "name": "reqOpts",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "request",
-          "params": [
-            {
-              "name": "reqOpts",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "rotateEncryptionKey",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "rotateEncryptionKey",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "rotateEncryptionKey",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "save",
-          "params": [
-            {
-              "name": "data",
-              "optional": false,
-              "type": "AnyKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "save",
-          "params": [
-            {
-              "name": "data",
-              "optional": false,
-              "type": "AnyKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "save",
-          "params": [
-            {
-              "name": "data",
-              "optional": false,
-              "type": "AnyKeyword"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setStorageClass",
-          "params": [
-            {
-              "name": "storageClass",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setStorageClass",
-          "params": [
-            {
-              "name": "storageClass",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setStorageClass",
-          "params": [
-            {
-              "name": "storageClass",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setUserProject",
-          "params": [
-            {
-              "name": "userProject",
-              "optional": false,
-              "type": "StringKeyword"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "startResumableUpload_",
-          "params": [
-            {
-              "name": "dup",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "startSimpleUpload_",
-          "params": [
-            {
-              "name": "dup",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        }
-      ],
-      "properties": [
-        {
-          "name": "acl",
-          "type": "TypeReference",
-          "typeRefName": "Acl"
-        },
-        {
-          "name": "bucket",
-          "type": "TypeReference",
-          "typeRefName": "Bucket"
-        },
-        {
-          "name": "storage",
-          "type": "TypeReference",
-          "typeRefName": "Storage"
-        },
-        {
-          "name": "kmsKeyName",
-          "type": "StringKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "userProject",
-          "type": "StringKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "signer",
-          "type": "TypeReference",
-          "typeRefName": "URLSigner"
-        },
-        {
-          "name": "name",
-          "type": "StringKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "generation",
-          "type": "NumberKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "parent",
-          "type": "TypeReference",
-          "typeRefName": "Bucket"
-        }
-      ],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "bucket",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "Bucket"
-          },
-          {
-            "name": "name",
-            "optional": false,
-            "type": "StringKeyword",
-            "typeRefName": null
-          },
-          {
-            "name": "options",
-            "optional": true,
-            "type": "TypeReference",
-            "typeRefName": "FileOptions"
-          }
-        ]
-      }
-    },
-    {
-      "name": "HmacKey",
-      "methods": [],
-      "properties": [
-        {
-          "name": "metadata",
-          "type": "UnionType",
-          "typeRefName": null
-        }
-      ],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "storage",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "Storage"
-          },
-          {
-            "name": "accessId",
-            "optional": false,
-            "type": "StringKeyword",
-            "typeRefName": null
-          },
-          {
-            "name": "options",
-            "optional": true,
-            "type": "TypeReference",
-            "typeRefName": "HmacKeyOptions"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Iam",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getPolicy",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getPolicy",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getPolicy",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setPolicy",
-          "params": [
-            {
-              "name": "policy",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setPolicy",
-          "params": [
-            {
-              "name": "policy",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setPolicy",
-          "params": [
-            {
-              "name": "policy",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "testPermissions",
-          "params": [
-            {
-              "name": "permissions",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "testPermissions",
-          "params": [
-            {
-              "name": "permissions",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "testPermissions",
-          "params": [
-            {
-              "name": "permissions",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Iam"
-        }
-      ],
-      "properties": [],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "bucket",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "Bucket"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Notification",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "delete",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "delete",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "delete",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "get",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "get",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "get",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getMetadata",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getMetadata",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getMetadata",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Notification"
-        }
-      ],
-      "properties": [],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "bucket",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "Bucket"
-          },
-          {
-            "name": "id",
-            "optional": false,
-            "type": "StringKeyword",
-            "typeRefName": null
-          }
-        ]
-      }
-    },
-    {
-      "name": "URLSigner",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "signer.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedUrl",
-          "params": [
-            {
-              "name": "cfg",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "URLSigner"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "signer.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getCanonicalHeaders",
-          "params": [
-            {
-              "name": "headers",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "StringKeyword",
-          "returnTypeName": null,
-          "client": "URLSigner"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "signer.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getCanonicalRequest",
-          "params": [
-            {
-              "name": "method",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "path",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "query",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "headers",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "signedHeaders",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "contentSha256",
-              "optional": true,
-              "type": "StringKeyword"
-            }
-          ],
-          "returnType": "StringKeyword",
-          "returnTypeName": null,
-          "client": "URLSigner"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "signer.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getCanonicalQueryParams",
-          "params": [
-            {
-              "name": "query",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "StringKeyword",
-          "returnTypeName": null,
-          "client": "URLSigner"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "signer.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getResourcePath",
-          "params": [
-            {
-              "name": "cname",
-              "optional": false,
-              "type": "BooleanKeyword"
-            },
-            {
-              "name": "bucket",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "file",
-              "optional": true,
-              "type": "StringKeyword"
-            }
-          ],
-          "returnType": "StringKeyword",
-          "returnTypeName": null,
-          "client": "URLSigner"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "signer.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "parseExpires",
-          "params": [
-            {
-              "name": "expires",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "current",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "NumberKeyword",
-          "returnTypeName": null,
-          "client": "URLSigner"
-        }
-      ],
-      "properties": [],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "authClient",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "AuthClient"
-          },
-          {
-            "name": "bucket",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "BucketI"
-          },
-          {
-            "name": "file",
-            "optional": true,
-            "type": "TypeReference",
-            "typeRefName": "FileI"
-          }
-        ]
-      }
-    },
-    {
-      "name": "SigningError",
-      "methods": [],
-      "properties": [
-        {
-          "name": "name",
-          "type": "StringKeyword",
-          "typeRefName": null
-        }
-      ],
-      "constructor": null
-    },
-    {
-      "name": "Storage",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "bucket",
-          "params": [
-            {
-              "name": "name",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Bucket",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "channel",
-          "params": [
-            {
-              "name": "id",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "resourceId",
-              "optional": false,
-              "type": "StringKeyword"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Channel",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createBucket",
-          "params": [
-            {
-              "name": "name",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "metadata",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createBucket",
-          "params": [
-            {
-              "name": "name",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createBucket",
-          "params": [
-            {
-              "name": "name",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "metadata",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createBucket",
-          "params": [
-            {
-              "name": "name",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "metadata",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createHmacKey",
-          "params": [
-            {
-              "name": "serviceAccountEmail",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createHmacKey",
-          "params": [
-            {
-              "name": "serviceAccountEmail",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createHmacKey",
-          "params": [
-            {
-              "name": "serviceAccountEmail",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getBuckets",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getBuckets",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getBuckets",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getHmacKeys",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getHmacKeys",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getHmacKeys",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getServiceAccount",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getServiceAccount",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getServiceAccount",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getServiceAccount",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "hmacKey",
-          "params": [
-            {
-              "name": "accessId",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "HmacKey",
-          "client": "Storage"
-        }
-      ],
-      "properties": [
-        {
-          "name": "Bucket",
-          "type": "TypeQuery",
-          "typeRefName": null
-        },
-        {
-          "name": "Channel",
-          "type": "TypeQuery",
-          "typeRefName": null
-        },
-        {
-          "name": "File",
-          "type": "TypeQuery",
-          "typeRefName": null
-        },
-        {
-          "name": "HmacKey",
-          "type": "TypeQuery",
-          "typeRefName": null
-        },
-        {
-          "name": "acl",
-          "type": "TypeLiteral",
-          "typeRefName": null
-        },
-        {
-          "name": "acl",
-          "type": "TypeQuery",
-          "typeRefName": null
-        },
-        {
-          "name": "getBucketsStream",
-          "type": "FunctionType",
-          "typeRefName": null
-        },
-        {
-          "name": "getHmacKeysStream",
-          "type": "FunctionType",
-          "typeRefName": null
-        }
-      ],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "options",
-            "optional": true,
-            "type": "TypeReference",
-            "typeRefName": "StorageOptions"
-          }
-        ]
-      }
-    }
-  ]
+	"mainClass": "Storage",
+	"functions": [
+		{
+			"functionName": "makePublic",
+			"SDKFunctionName": "makePublic",
+			"params": [],
+			"pkgName": "storage",
+			"fileName": "file.d.ts",
+			"client": "File",
+			"returnType": "TypeReference",
+			"returnTypeName": "Promise",
+			"classConstructorData": {
+				"parameters": [
+					{
+						"name": "bucket",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "Bucket"
+					},
+					{
+						"name": "name",
+						"optional": false,
+						"type": "StringKeyword",
+						"typeRefName": null
+					},
+					{
+						"name": "options",
+						"optional": true,
+						"type": "TypeReference",
+						"typeRefName": "FileOptions"
+					}
+				]
+			}
+		}
+	],
+	"classData": [
+		{
+			"name": "AclRoleAccessorMethods",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "_assignAccessMethods",
+					"params": [
+						{
+							"name": "role",
+							"optional": false,
+							"type": "StringKeyword"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "AclRoleAccessorMethods"
+				}
+			],
+			"properties": [
+				{
+					"name": "owners",
+					"type": "TypeLiteral",
+					"typeRefName": null
+				},
+				{
+					"name": "readers",
+					"type": "TypeLiteral",
+					"typeRefName": null
+				},
+				{
+					"name": "writers",
+					"type": "TypeLiteral",
+					"typeRefName": null
+				}
+			],
+			"constructor": {
+				"parameters": []
+			}
+		},
+		{
+			"name": "Acl",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "add",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "add",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "delete",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "delete",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "get",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "get",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "get",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "update",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "update",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makeAclObject_",
+					"params": [
+						{
+							"name": "accessControlObject",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "AccessControlObject",
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "request",
+					"params": [
+						{
+							"name": "reqOpts",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Acl"
+				}
+			],
+			"properties": [
+				{
+					"name": "default",
+					"type": "TypeReference",
+					"typeRefName": "Acl"
+				},
+				{
+					"name": "pathPrefix",
+					"type": "StringKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "request_",
+					"type": "FunctionType",
+					"typeRefName": null
+				}
+			],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "options",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "AclOptions"
+					}
+				]
+			}
+		},
+		{
+			"name": "Bucket",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "addLifecycleRule",
+					"params": [
+						{
+							"name": "rule",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "addLifecycleRule",
+					"params": [
+						{
+							"name": "rule",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "addLifecycleRule",
+					"params": [
+						{
+							"name": "rule",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "combine",
+					"params": [
+						{
+							"name": "sources",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "combine",
+					"params": [
+						{
+							"name": "sources",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "combine",
+					"params": [
+						{
+							"name": "sources",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createChannel",
+					"params": [
+						{
+							"name": "id",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "config",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createChannel",
+					"params": [
+						{
+							"name": "id",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "config",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createChannel",
+					"params": [
+						{
+							"name": "id",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "config",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createNotification",
+					"params": [
+						{
+							"name": "topic",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createNotification",
+					"params": [
+						{
+							"name": "topic",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createNotification",
+					"params": [
+						{
+							"name": "topic",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "deleteFiles",
+					"params": [
+						{
+							"name": "query",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "deleteFiles",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "deleteFiles",
+					"params": [
+						{
+							"name": "query",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "deleteLabels",
+					"params": [
+						{
+							"name": "labels",
+							"optional": true,
+							"type": "UnionType"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "deleteLabels",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "deleteLabels",
+					"params": [
+						{
+							"name": "labels",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "disableRequesterPays",
+					"params": [],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "disableRequesterPays",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "enableLogging",
+					"params": [
+						{
+							"name": "config",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "enableLogging",
+					"params": [
+						{
+							"name": "config",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "enableRequesterPays",
+					"params": [],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "enableRequesterPays",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "file",
+					"params": [
+						{
+							"name": "name",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "File",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getFiles",
+					"params": [
+						{
+							"name": "query",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getFiles",
+					"params": [
+						{
+							"name": "query",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getFiles",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getLabels",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getLabels",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getLabels",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getNotifications",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getNotifications",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getNotifications",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedUrl",
+					"params": [
+						{
+							"name": "cfg",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedUrl",
+					"params": [
+						{
+							"name": "cfg",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "lock",
+					"params": [
+						{
+							"name": "metageneration",
+							"optional": false,
+							"type": "UnionType"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "lock",
+					"params": [
+						{
+							"name": "metageneration",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePrivate",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePrivate",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePrivate",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePublic",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePublic",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePublic",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "notification",
+					"params": [
+						{
+							"name": "id",
+							"optional": false,
+							"type": "StringKeyword"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Notification",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "removeRetentionPeriod",
+					"params": [],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "removeRetentionPeriod",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "request",
+					"params": [
+						{
+							"name": "reqOpts",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "request",
+					"params": [
+						{
+							"name": "reqOpts",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setLabels",
+					"params": [
+						{
+							"name": "labels",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setLabels",
+					"params": [
+						{
+							"name": "labels",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setLabels",
+					"params": [
+						{
+							"name": "labels",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setRetentionPeriod",
+					"params": [
+						{
+							"name": "duration",
+							"optional": false,
+							"type": "NumberKeyword"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setRetentionPeriod",
+					"params": [
+						{
+							"name": "duration",
+							"optional": false,
+							"type": "NumberKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setCorsConfiguration",
+					"params": [
+						{
+							"name": "corsConfiguration",
+							"optional": false,
+							"type": "ArrayType"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setCorsConfiguration",
+					"params": [
+						{
+							"name": "corsConfiguration",
+							"optional": false,
+							"type": "ArrayType"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setStorageClass",
+					"params": [
+						{
+							"name": "storageClass",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setStorageClass",
+					"params": [
+						{
+							"name": "storageClass",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setStorageClass",
+					"params": [
+						{
+							"name": "storageClass",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setUserProject",
+					"params": [
+						{
+							"name": "userProject",
+							"optional": false,
+							"type": "StringKeyword"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "upload",
+					"params": [
+						{
+							"name": "pathString",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "upload",
+					"params": [
+						{
+							"name": "pathString",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "upload",
+					"params": [
+						{
+							"name": "pathString",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makeAllFilesPublicPrivate_",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makeAllFilesPublicPrivate_",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makeAllFilesPublicPrivate_",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getId",
+					"params": [],
+					"returnType": "StringKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				}
+			],
+			"properties": [
+				{
+					"name": "name",
+					"type": "StringKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "storage",
+					"type": "TypeReference",
+					"typeRefName": "Storage"
+				},
+				{
+					"name": "userProject",
+					"type": "StringKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "acl",
+					"type": "TypeReference",
+					"typeRefName": "Acl"
+				},
+				{
+					"name": "iam",
+					"type": "TypeReference",
+					"typeRefName": "Iam"
+				},
+				{
+					"name": "getFilesStream",
+					"type": "TypeReference",
+					"typeRefName": "Function"
+				},
+				{
+					"name": "signer",
+					"type": "TypeReference",
+					"typeRefName": "URLSigner"
+				}
+			],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "storage",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "Storage"
+					},
+					{
+						"name": "name",
+						"optional": false,
+						"type": "StringKeyword",
+						"typeRefName": null
+					},
+					{
+						"name": "options",
+						"optional": true,
+						"type": "TypeReference",
+						"typeRefName": "BucketOptions"
+					}
+				]
+			}
+		},
+		{
+			"name": "Channel",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "channel.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "stop",
+					"params": [],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Channel"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "channel.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "stop",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Channel"
+				}
+			],
+			"properties": [],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "storage",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "Storage"
+					},
+					{
+						"name": "id",
+						"optional": false,
+						"type": "StringKeyword",
+						"typeRefName": null
+					},
+					{
+						"name": "resourceId",
+						"optional": false,
+						"type": "StringKeyword",
+						"typeRefName": null
+					}
+				]
+			}
+		},
+		{
+			"name": "RequestError",
+			"methods": [],
+			"properties": [
+				{
+					"name": "code",
+					"type": "StringKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "errors",
+					"type": "ArrayType",
+					"typeRefName": null
+				}
+			],
+			"constructor": null
+		},
+		{
+			"name": "File",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "copy",
+					"params": [
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "copy",
+					"params": [
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "copy",
+					"params": [
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createReadStream",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Readable",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createResumableUpload",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createResumableUpload",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createResumableUpload",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createWriteStream",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Writable",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "deleteResumableCache",
+					"params": [],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "download",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "download",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "download",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setEncryptionKey",
+					"params": [
+						{
+							"name": "encryptionKey",
+							"optional": false,
+							"type": "UnionType"
+						}
+					],
+					"returnType": "ThisType",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getExpirationDate",
+					"params": [],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getExpirationDate",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedPolicy",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedPolicy",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedPolicy",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "generateSignedPostPolicyV2",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "generateSignedPostPolicyV2",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "generateSignedPostPolicyV2",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "generateSignedPostPolicyV4",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "generateSignedPostPolicyV4",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "generateSignedPostPolicyV4",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedUrl",
+					"params": [
+						{
+							"name": "cfg",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedUrl",
+					"params": [
+						{
+							"name": "cfg",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "isPublic",
+					"params": [],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "isPublic",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePrivate",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePrivate",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePrivate",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": "makePublic",
+					"SDKFunctionName": "makePublic",
+					"params": [],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File",
+					"classConstructorData": {
+						"parameters": [
+							{
+								"name": "bucket",
+								"optional": false,
+								"type": "TypeReference",
+								"typeRefName": "Bucket"
+							},
+							{
+								"name": "name",
+								"optional": false,
+								"type": "StringKeyword",
+								"typeRefName": null
+							},
+							{
+								"name": "options",
+								"optional": true,
+								"type": "TypeReference",
+								"typeRefName": "FileOptions"
+							}
+						]
+					}
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": "makePublic",
+					"SDKFunctionName": "makePublic",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File",
+					"classConstructorData": {
+						"parameters": [
+							{
+								"name": "bucket",
+								"optional": false,
+								"type": "TypeReference",
+								"typeRefName": "Bucket"
+							},
+							{
+								"name": "name",
+								"optional": false,
+								"type": "StringKeyword",
+								"typeRefName": null
+							},
+							{
+								"name": "options",
+								"optional": true,
+								"type": "TypeReference",
+								"typeRefName": "FileOptions"
+							}
+						]
+					}
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "move",
+					"params": [
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "move",
+					"params": [
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "move",
+					"params": [
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "request",
+					"params": [
+						{
+							"name": "reqOpts",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "request",
+					"params": [
+						{
+							"name": "reqOpts",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "rotateEncryptionKey",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "rotateEncryptionKey",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "rotateEncryptionKey",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "save",
+					"params": [
+						{
+							"name": "data",
+							"optional": false,
+							"type": "AnyKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "save",
+					"params": [
+						{
+							"name": "data",
+							"optional": false,
+							"type": "AnyKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "save",
+					"params": [
+						{
+							"name": "data",
+							"optional": false,
+							"type": "AnyKeyword"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setStorageClass",
+					"params": [
+						{
+							"name": "storageClass",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setStorageClass",
+					"params": [
+						{
+							"name": "storageClass",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setStorageClass",
+					"params": [
+						{
+							"name": "storageClass",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setUserProject",
+					"params": [
+						{
+							"name": "userProject",
+							"optional": false,
+							"type": "StringKeyword"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "startResumableUpload_",
+					"params": [
+						{
+							"name": "dup",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "startSimpleUpload_",
+					"params": [
+						{
+							"name": "dup",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				}
+			],
+			"properties": [
+				{
+					"name": "acl",
+					"type": "TypeReference",
+					"typeRefName": "Acl"
+				},
+				{
+					"name": "bucket",
+					"type": "TypeReference",
+					"typeRefName": "Bucket"
+				},
+				{
+					"name": "storage",
+					"type": "TypeReference",
+					"typeRefName": "Storage"
+				},
+				{
+					"name": "kmsKeyName",
+					"type": "StringKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "userProject",
+					"type": "StringKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "signer",
+					"type": "TypeReference",
+					"typeRefName": "URLSigner"
+				},
+				{
+					"name": "name",
+					"type": "StringKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "generation",
+					"type": "NumberKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "parent",
+					"type": "TypeReference",
+					"typeRefName": "Bucket"
+				}
+			],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "bucket",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "Bucket"
+					},
+					{
+						"name": "name",
+						"optional": false,
+						"type": "StringKeyword",
+						"typeRefName": null
+					},
+					{
+						"name": "options",
+						"optional": true,
+						"type": "TypeReference",
+						"typeRefName": "FileOptions"
+					}
+				]
+			}
+		},
+		{
+			"name": "HmacKey",
+			"methods": [],
+			"properties": [
+				{
+					"name": "metadata",
+					"type": "UnionType",
+					"typeRefName": null
+				}
+			],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "storage",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "Storage"
+					},
+					{
+						"name": "accessId",
+						"optional": false,
+						"type": "StringKeyword",
+						"typeRefName": null
+					},
+					{
+						"name": "options",
+						"optional": true,
+						"type": "TypeReference",
+						"typeRefName": "HmacKeyOptions"
+					}
+				]
+			}
+		},
+		{
+			"name": "Iam",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getPolicy",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getPolicy",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getPolicy",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setPolicy",
+					"params": [
+						{
+							"name": "policy",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setPolicy",
+					"params": [
+						{
+							"name": "policy",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setPolicy",
+					"params": [
+						{
+							"name": "policy",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "testPermissions",
+					"params": [
+						{
+							"name": "permissions",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "testPermissions",
+					"params": [
+						{
+							"name": "permissions",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "testPermissions",
+					"params": [
+						{
+							"name": "permissions",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Iam"
+				}
+			],
+			"properties": [],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "bucket",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "Bucket"
+					}
+				]
+			}
+		},
+		{
+			"name": "Notification",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "delete",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "delete",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "delete",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "get",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "get",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "get",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getMetadata",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getMetadata",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getMetadata",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Notification"
+				}
+			],
+			"properties": [],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "bucket",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "Bucket"
+					},
+					{
+						"name": "id",
+						"optional": false,
+						"type": "StringKeyword",
+						"typeRefName": null
+					}
+				]
+			}
+		},
+		{
+			"name": "URLSigner",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "signer.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedUrl",
+					"params": [
+						{
+							"name": "cfg",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "URLSigner"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "signer.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getCanonicalHeaders",
+					"params": [
+						{
+							"name": "headers",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "StringKeyword",
+					"returnTypeName": null,
+					"client": "URLSigner"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "signer.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getCanonicalRequest",
+					"params": [
+						{
+							"name": "method",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "path",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "query",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "headers",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "signedHeaders",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "contentSha256",
+							"optional": true,
+							"type": "StringKeyword"
+						}
+					],
+					"returnType": "StringKeyword",
+					"returnTypeName": null,
+					"client": "URLSigner"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "signer.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getCanonicalQueryParams",
+					"params": [
+						{
+							"name": "query",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "StringKeyword",
+					"returnTypeName": null,
+					"client": "URLSigner"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "signer.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getResourcePath",
+					"params": [
+						{
+							"name": "cname",
+							"optional": false,
+							"type": "BooleanKeyword"
+						},
+						{
+							"name": "bucket",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "file",
+							"optional": true,
+							"type": "StringKeyword"
+						}
+					],
+					"returnType": "StringKeyword",
+					"returnTypeName": null,
+					"client": "URLSigner"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "signer.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "parseExpires",
+					"params": [
+						{
+							"name": "expires",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "current",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "NumberKeyword",
+					"returnTypeName": null,
+					"client": "URLSigner"
+				}
+			],
+			"properties": [],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "authClient",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "AuthClient"
+					},
+					{
+						"name": "bucket",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "BucketI"
+					},
+					{
+						"name": "file",
+						"optional": true,
+						"type": "TypeReference",
+						"typeRefName": "FileI"
+					}
+				]
+			}
+		},
+		{
+			"name": "SigningError",
+			"methods": [],
+			"properties": [
+				{
+					"name": "name",
+					"type": "StringKeyword",
+					"typeRefName": null
+				}
+			],
+			"constructor": null
+		},
+		{
+			"name": "Storage",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "bucket",
+					"params": [
+						{
+							"name": "name",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Bucket",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "channel",
+					"params": [
+						{
+							"name": "id",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "resourceId",
+							"optional": false,
+							"type": "StringKeyword"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Channel",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createBucket",
+					"params": [
+						{
+							"name": "name",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "metadata",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createBucket",
+					"params": [
+						{
+							"name": "name",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createBucket",
+					"params": [
+						{
+							"name": "name",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "metadata",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createBucket",
+					"params": [
+						{
+							"name": "name",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "metadata",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createHmacKey",
+					"params": [
+						{
+							"name": "serviceAccountEmail",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createHmacKey",
+					"params": [
+						{
+							"name": "serviceAccountEmail",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createHmacKey",
+					"params": [
+						{
+							"name": "serviceAccountEmail",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getBuckets",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getBuckets",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getBuckets",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getHmacKeys",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getHmacKeys",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getHmacKeys",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getServiceAccount",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getServiceAccount",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getServiceAccount",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getServiceAccount",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "hmacKey",
+					"params": [
+						{
+							"name": "accessId",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "HmacKey",
+					"client": "Storage"
+				}
+			],
+			"properties": [
+				{
+					"name": "Bucket",
+					"type": "TypeQuery",
+					"typeRefName": null
+				},
+				{
+					"name": "Channel",
+					"type": "TypeQuery",
+					"typeRefName": null
+				},
+				{
+					"name": "File",
+					"type": "TypeQuery",
+					"typeRefName": null
+				},
+				{
+					"name": "HmacKey",
+					"type": "TypeQuery",
+					"typeRefName": null
+				},
+				{
+					"name": "acl",
+					"type": "TypeLiteral",
+					"typeRefName": null
+				},
+				{
+					"name": "acl",
+					"type": "TypeQuery",
+					"typeRefName": null
+				},
+				{
+					"name": "getBucketsStream",
+					"type": "FunctionType",
+					"typeRefName": null
+				},
+				{
+					"name": "getHmacKeysStream",
+					"type": "FunctionType",
+					"typeRefName": null
+				}
+			],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "options",
+						"optional": true,
+						"type": "TypeReference",
+						"typeRefName": "StorageOptions"
+					}
+				]
+			}
+		}
+	]
 }

--- a/generator/test/transformers/googleCloud/dummyData/classBasedTransformer/validDataset/data.json
+++ b/generator/test/transformers/googleCloud/dummyData/classBasedTransformer/validDataset/data.json
@@ -1,3997 +1,3997 @@
 {
-  "mainClass": "Storage",
-  "functions": [
-    {
-      "functionName": "makePublic",
-      "SDKFunctionName": "makePublic",
-      "params": [],
-      "pkgName": "storage",
-      "fileName": "file.d.ts",
-      "client": "File",
-      "returnType": "TypeReference",
-      "returnTypeName": "Promise",
-      "classConstructorData": {
-        "parameters": [
-          {
-            "name": "bucket",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "Bucket"
-          },
-          {
-            "name": "name",
-            "optional": false,
-            "type": "StringKeyword",
-            "typeRefName": null
-          },
-          {
-            "name": "options",
-            "optional": true,
-            "type": "TypeReference",
-            "typeRefName": "FileOptions"
-          }
-        ]
-      }
-    }
-  ],
-  "classData": [
-    {
-      "name": "AclRoleAccessorMethods",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "_assignAccessMethods",
-          "params": [
-            {
-              "name": "role",
-              "optional": false,
-              "type": "StringKeyword"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "AclRoleAccessorMethods"
-        }
-      ],
-      "properties": [
-        {
-          "name": "owners",
-          "type": "TypeLiteral",
-          "typeRefName": null
-        },
-        {
-          "name": "readers",
-          "type": "TypeLiteral",
-          "typeRefName": null
-        },
-        {
-          "name": "writers",
-          "type": "TypeLiteral",
-          "typeRefName": null
-        }
-      ],
-      "constructor": {
-        "parameters": []
-      }
-    },
-    {
-      "name": "Acl",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "add",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "add",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "delete",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "delete",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "get",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "get",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "get",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "update",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "update",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makeAclObject_",
-          "params": [
-            {
-              "name": "accessControlObject",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "AccessControlObject",
-          "client": "Acl"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "acl.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "request",
-          "params": [
-            {
-              "name": "reqOpts",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Acl"
-        }
-      ],
-      "properties": [
-        {
-          "name": "default",
-          "type": "TypeReference",
-          "typeRefName": "Acl"
-        },
-        {
-          "name": "pathPrefix",
-          "type": "StringKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "request_",
-          "type": "FunctionType",
-          "typeRefName": null
-        }
-      ],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "options",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "AclOptions"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Bucket",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "addLifecycleRule",
-          "params": [
-            {
-              "name": "rule",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "addLifecycleRule",
-          "params": [
-            {
-              "name": "rule",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "addLifecycleRule",
-          "params": [
-            {
-              "name": "rule",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "combine",
-          "params": [
-            {
-              "name": "sources",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "combine",
-          "params": [
-            {
-              "name": "sources",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "combine",
-          "params": [
-            {
-              "name": "sources",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createChannel",
-          "params": [
-            {
-              "name": "id",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "config",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createChannel",
-          "params": [
-            {
-              "name": "id",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "config",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createChannel",
-          "params": [
-            {
-              "name": "id",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "config",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createNotification",
-          "params": [
-            {
-              "name": "topic",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createNotification",
-          "params": [
-            {
-              "name": "topic",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createNotification",
-          "params": [
-            {
-              "name": "topic",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "deleteFiles",
-          "params": [
-            {
-              "name": "query",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "deleteFiles",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "deleteFiles",
-          "params": [
-            {
-              "name": "query",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "deleteLabels",
-          "params": [
-            {
-              "name": "labels",
-              "optional": true,
-              "type": "UnionType"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "deleteLabels",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "deleteLabels",
-          "params": [
-            {
-              "name": "labels",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "disableRequesterPays",
-          "params": [],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "disableRequesterPays",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "enableLogging",
-          "params": [
-            {
-              "name": "config",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "enableLogging",
-          "params": [
-            {
-              "name": "config",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "enableRequesterPays",
-          "params": [],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "enableRequesterPays",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "file",
-          "params": [
-            {
-              "name": "name",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "File",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getFiles",
-          "params": [
-            {
-              "name": "query",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getFiles",
-          "params": [
-            {
-              "name": "query",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getFiles",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getLabels",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getLabels",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getLabels",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getNotifications",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getNotifications",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getNotifications",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedUrl",
-          "params": [
-            {
-              "name": "cfg",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedUrl",
-          "params": [
-            {
-              "name": "cfg",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "lock",
-          "params": [
-            {
-              "name": "metageneration",
-              "optional": false,
-              "type": "UnionType"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "lock",
-          "params": [
-            {
-              "name": "metageneration",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePrivate",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePrivate",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePrivate",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePublic",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePublic",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePublic",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "notification",
-          "params": [
-            {
-              "name": "id",
-              "optional": false,
-              "type": "StringKeyword"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Notification",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "removeRetentionPeriod",
-          "params": [],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "removeRetentionPeriod",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "request",
-          "params": [
-            {
-              "name": "reqOpts",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "request",
-          "params": [
-            {
-              "name": "reqOpts",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setLabels",
-          "params": [
-            {
-              "name": "labels",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setLabels",
-          "params": [
-            {
-              "name": "labels",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setLabels",
-          "params": [
-            {
-              "name": "labels",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setRetentionPeriod",
-          "params": [
-            {
-              "name": "duration",
-              "optional": false,
-              "type": "NumberKeyword"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setRetentionPeriod",
-          "params": [
-            {
-              "name": "duration",
-              "optional": false,
-              "type": "NumberKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setCorsConfiguration",
-          "params": [
-            {
-              "name": "corsConfiguration",
-              "optional": false,
-              "type": "ArrayType"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setCorsConfiguration",
-          "params": [
-            {
-              "name": "corsConfiguration",
-              "optional": false,
-              "type": "ArrayType"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setStorageClass",
-          "params": [
-            {
-              "name": "storageClass",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setStorageClass",
-          "params": [
-            {
-              "name": "storageClass",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setStorageClass",
-          "params": [
-            {
-              "name": "storageClass",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setUserProject",
-          "params": [
-            {
-              "name": "userProject",
-              "optional": false,
-              "type": "StringKeyword"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "upload",
-          "params": [
-            {
-              "name": "pathString",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "upload",
-          "params": [
-            {
-              "name": "pathString",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "upload",
-          "params": [
-            {
-              "name": "pathString",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makeAllFilesPublicPrivate_",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makeAllFilesPublicPrivate_",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makeAllFilesPublicPrivate_",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "bucket.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getId",
-          "params": [],
-          "returnType": "StringKeyword",
-          "returnTypeName": null,
-          "client": "Bucket"
-        }
-      ],
-      "properties": [
-        {
-          "name": "name",
-          "type": "StringKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "storage",
-          "type": "TypeReference",
-          "typeRefName": "Storage"
-        },
-        {
-          "name": "userProject",
-          "type": "StringKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "acl",
-          "type": "TypeReference",
-          "typeRefName": "Acl"
-        },
-        {
-          "name": "iam",
-          "type": "TypeReference",
-          "typeRefName": "Iam"
-        },
-        {
-          "name": "getFilesStream",
-          "type": "TypeReference",
-          "typeRefName": "Function"
-        },
-        {
-          "name": "signer",
-          "type": "TypeReference",
-          "typeRefName": "URLSigner"
-        }
-      ],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "storage",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "Storage"
-          },
-          {
-            "name": "name",
-            "optional": false,
-            "type": "StringKeyword",
-            "typeRefName": null
-          },
-          {
-            "name": "options",
-            "optional": true,
-            "type": "TypeReference",
-            "typeRefName": "BucketOptions"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Channel",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "channel.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "stop",
-          "params": [],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Channel"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "channel.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "stop",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Channel"
-        }
-      ],
-      "properties": [],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "storage",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "Storage"
-          },
-          {
-            "name": "id",
-            "optional": false,
-            "type": "StringKeyword",
-            "typeRefName": null
-          },
-          {
-            "name": "resourceId",
-            "optional": false,
-            "type": "StringKeyword",
-            "typeRefName": null
-          }
-        ]
-      }
-    },
-    {
-      "name": "RequestError",
-      "methods": [],
-      "properties": [
-        {
-          "name": "code",
-          "type": "StringKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "errors",
-          "type": "ArrayType",
-          "typeRefName": null
-        }
-      ],
-      "constructor": null
-    },
-    {
-      "name": "File",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "copy",
-          "params": [
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "copy",
-          "params": [
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "copy",
-          "params": [
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createReadStream",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Readable",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createResumableUpload",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createResumableUpload",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createResumableUpload",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createWriteStream",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Writable",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "deleteResumableCache",
-          "params": [],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "download",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "download",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "download",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setEncryptionKey",
-          "params": [
-            {
-              "name": "encryptionKey",
-              "optional": false,
-              "type": "UnionType"
-            }
-          ],
-          "returnType": "ThisType",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getExpirationDate",
-          "params": [],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getExpirationDate",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedPolicy",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedPolicy",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedPolicy",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "generateSignedPostPolicyV2",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "generateSignedPostPolicyV2",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "generateSignedPostPolicyV2",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "generateSignedPostPolicyV4",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "generateSignedPostPolicyV4",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "generateSignedPostPolicyV4",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedUrl",
-          "params": [
-            {
-              "name": "cfg",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedUrl",
-          "params": [
-            {
-              "name": "cfg",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "isPublic",
-          "params": [],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "isPublic",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePrivate",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePrivate",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "makePrivate",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": "makePublic",
-          "SDKFunctionName": "makePublic",
-          "params": [],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File",
-          "classConstructorData": {
-            "parameters": [
-              {
-                "name": "bucket",
-                "optional": false,
-                "type": "TypeReference",
-                "typeRefName": "Bucket"
-              },
-              {
-                "name": "name",
-                "optional": false,
-                "type": "StringKeyword",
-                "typeRefName": null
-              },
-              {
-                "name": "options",
-                "optional": true,
-                "type": "TypeReference",
-                "typeRefName": "FileOptions"
-              }
-            ]
-          }
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": "makePublic",
-          "SDKFunctionName": "makePublic",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File",
-          "classConstructorData": {
-            "parameters": [
-              {
-                "name": "bucket",
-                "optional": false,
-                "type": "TypeReference",
-                "typeRefName": "Bucket"
-              },
-              {
-                "name": "name",
-                "optional": false,
-                "type": "StringKeyword",
-                "typeRefName": null
-              },
-              {
-                "name": "options",
-                "optional": true,
-                "type": "TypeReference",
-                "typeRefName": "FileOptions"
-              }
-            ]
-          }
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "move",
-          "params": [
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "move",
-          "params": [
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "move",
-          "params": [
-            {
-              "name": "destination",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "request",
-          "params": [
-            {
-              "name": "reqOpts",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "request",
-          "params": [
-            {
-              "name": "reqOpts",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "rotateEncryptionKey",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "rotateEncryptionKey",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "rotateEncryptionKey",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "save",
-          "params": [
-            {
-              "name": "data",
-              "optional": false,
-              "type": "AnyKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "save",
-          "params": [
-            {
-              "name": "data",
-              "optional": false,
-              "type": "AnyKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "save",
-          "params": [
-            {
-              "name": "data",
-              "optional": false,
-              "type": "AnyKeyword"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setStorageClass",
-          "params": [
-            {
-              "name": "storageClass",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setStorageClass",
-          "params": [
-            {
-              "name": "storageClass",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setStorageClass",
-          "params": [
-            {
-              "name": "storageClass",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setUserProject",
-          "params": [
-            {
-              "name": "userProject",
-              "optional": false,
-              "type": "StringKeyword"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "startResumableUpload_",
-          "params": [
-            {
-              "name": "dup",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "file.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "startSimpleUpload_",
-          "params": [
-            {
-              "name": "dup",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "File"
-        }
-      ],
-      "properties": [
-        {
-          "name": "acl",
-          "type": "TypeReference",
-          "typeRefName": "Acl"
-        },
-        {
-          "name": "bucket",
-          "type": "TypeReference",
-          "typeRefName": "Bucket"
-        },
-        {
-          "name": "storage",
-          "type": "TypeReference",
-          "typeRefName": "Storage"
-        },
-        {
-          "name": "kmsKeyName",
-          "type": "StringKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "userProject",
-          "type": "StringKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "signer",
-          "type": "TypeReference",
-          "typeRefName": "URLSigner"
-        },
-        {
-          "name": "name",
-          "type": "StringKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "generation",
-          "type": "NumberKeyword",
-          "typeRefName": null
-        },
-        {
-          "name": "parent",
-          "type": "TypeReference",
-          "typeRefName": "Bucket"
-        }
-      ],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "bucket",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "Bucket"
-          },
-          {
-            "name": "name",
-            "optional": false,
-            "type": "StringKeyword",
-            "typeRefName": null
-          },
-          {
-            "name": "options",
-            "optional": true,
-            "type": "TypeReference",
-            "typeRefName": "FileOptions"
-          }
-        ]
-      }
-    },
-    {
-      "name": "HmacKey",
-      "methods": [],
-      "properties": [
-        {
-          "name": "metadata",
-          "type": "UnionType",
-          "typeRefName": null
-        }
-      ],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "storage",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "Storage"
-          },
-          {
-            "name": "accessId",
-            "optional": false,
-            "type": "StringKeyword",
-            "typeRefName": null
-          },
-          {
-            "name": "options",
-            "optional": true,
-            "type": "TypeReference",
-            "typeRefName": "HmacKeyOptions"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Iam",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getPolicy",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getPolicy",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getPolicy",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setPolicy",
-          "params": [
-            {
-              "name": "policy",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setPolicy",
-          "params": [
-            {
-              "name": "policy",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "setPolicy",
-          "params": [
-            {
-              "name": "policy",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "testPermissions",
-          "params": [
-            {
-              "name": "permissions",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "testPermissions",
-          "params": [
-            {
-              "name": "permissions",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Iam"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "iam.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "testPermissions",
-          "params": [
-            {
-              "name": "permissions",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Iam"
-        }
-      ],
-      "properties": [],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "bucket",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "Bucket"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Notification",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "delete",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "delete",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "delete",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "get",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "get",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "get",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getMetadata",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getMetadata",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Notification"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "notification.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getMetadata",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Notification"
-        }
-      ],
-      "properties": [],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "bucket",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "Bucket"
-          },
-          {
-            "name": "id",
-            "optional": false,
-            "type": "StringKeyword",
-            "typeRefName": null
-          }
-        ]
-      }
-    },
-    {
-      "name": "URLSigner",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "signer.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getSignedUrl",
-          "params": [
-            {
-              "name": "cfg",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "URLSigner"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "signer.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getCanonicalHeaders",
-          "params": [
-            {
-              "name": "headers",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "StringKeyword",
-          "returnTypeName": null,
-          "client": "URLSigner"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "signer.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getCanonicalRequest",
-          "params": [
-            {
-              "name": "method",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "path",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "query",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "headers",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "signedHeaders",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "contentSha256",
-              "optional": true,
-              "type": "StringKeyword"
-            }
-          ],
-          "returnType": "StringKeyword",
-          "returnTypeName": null,
-          "client": "URLSigner"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "signer.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getCanonicalQueryParams",
-          "params": [
-            {
-              "name": "query",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "StringKeyword",
-          "returnTypeName": null,
-          "client": "URLSigner"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "signer.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getResourcePath",
-          "params": [
-            {
-              "name": "cname",
-              "optional": false,
-              "type": "BooleanKeyword"
-            },
-            {
-              "name": "bucket",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "file",
-              "optional": true,
-              "type": "StringKeyword"
-            }
-          ],
-          "returnType": "StringKeyword",
-          "returnTypeName": null,
-          "client": "URLSigner"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "signer.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "parseExpires",
-          "params": [
-            {
-              "name": "expires",
-              "optional": false,
-              "type": "UnionType"
-            },
-            {
-              "name": "current",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "NumberKeyword",
-          "returnTypeName": null,
-          "client": "URLSigner"
-        }
-      ],
-      "properties": [],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "authClient",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "AuthClient"
-          },
-          {
-            "name": "bucket",
-            "optional": false,
-            "type": "TypeReference",
-            "typeRefName": "BucketI"
-          },
-          {
-            "name": "file",
-            "optional": true,
-            "type": "TypeReference",
-            "typeRefName": "FileI"
-          }
-        ]
-      }
-    },
-    {
-      "name": "SigningError",
-      "methods": [],
-      "properties": [
-        {
-          "name": "name",
-          "type": "StringKeyword",
-          "typeRefName": null
-        }
-      ],
-      "constructor": null
-    },
-    {
-      "name": "Storage",
-      "methods": [
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "bucket",
-          "params": [
-            {
-              "name": "name",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Bucket",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "channel",
-          "params": [
-            {
-              "name": "id",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "resourceId",
-              "optional": false,
-              "type": "StringKeyword"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Channel",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createBucket",
-          "params": [
-            {
-              "name": "name",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "metadata",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createBucket",
-          "params": [
-            {
-              "name": "name",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createBucket",
-          "params": [
-            {
-              "name": "name",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "metadata",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createBucket",
-          "params": [
-            {
-              "name": "name",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "metadata",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createHmacKey",
-          "params": [
-            {
-              "name": "serviceAccountEmail",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createHmacKey",
-          "params": [
-            {
-              "name": "serviceAccountEmail",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "createHmacKey",
-          "params": [
-            {
-              "name": "serviceAccountEmail",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getBuckets",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getBuckets",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getBuckets",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getHmacKeys",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getHmacKeys",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getHmacKeys",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getServiceAccount",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getServiceAccount",
-          "params": [
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "Promise",
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getServiceAccount",
-          "params": [
-            {
-              "name": "options",
-              "optional": false,
-              "type": "TypeReference"
-            },
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "getServiceAccount",
-          "params": [
-            {
-              "name": "callback",
-              "optional": false,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "VoidKeyword",
-          "returnTypeName": null,
-          "client": "Storage"
-        },
-        {
-          "pkgName": "storage",
-          "version": null,
-          "fileName": "storage.d.ts",
-          "functionName": null,
-          "SDKFunctionName": "hmacKey",
-          "params": [
-            {
-              "name": "accessId",
-              "optional": false,
-              "type": "StringKeyword"
-            },
-            {
-              "name": "options",
-              "optional": true,
-              "type": "TypeReference"
-            }
-          ],
-          "returnType": "TypeReference",
-          "returnTypeName": "HmacKey",
-          "client": "Storage"
-        }
-      ],
-      "properties": [
-        {
-          "name": "Bucket",
-          "type": "TypeQuery",
-          "typeRefName": null
-        },
-        {
-          "name": "Channel",
-          "type": "TypeQuery",
-          "typeRefName": null
-        },
-        {
-          "name": "File",
-          "type": "TypeQuery",
-          "typeRefName": null
-        },
-        {
-          "name": "HmacKey",
-          "type": "TypeQuery",
-          "typeRefName": null
-        },
-        {
-          "name": "acl",
-          "type": "TypeLiteral",
-          "typeRefName": null
-        },
-        {
-          "name": "acl",
-          "type": "TypeQuery",
-          "typeRefName": null
-        },
-        {
-          "name": "getBucketsStream",
-          "type": "FunctionType",
-          "typeRefName": null
-        },
-        {
-          "name": "getHmacKeysStream",
-          "type": "FunctionType",
-          "typeRefName": null
-        }
-      ],
-      "constructor": {
-        "parameters": [
-          {
-            "name": "options",
-            "optional": true,
-            "type": "TypeReference",
-            "typeRefName": "StorageOptions"
-          }
-        ]
-      }
-    }
-  ]
+	"mainClass": "Storage",
+	"functions": [
+		{
+			"functionName": "makePublic",
+			"SDKFunctionName": "makePublic",
+			"params": [],
+			"pkgName": "storage",
+			"fileName": "file.d.ts",
+			"client": "File",
+			"returnType": "TypeReference",
+			"returnTypeName": "Promise",
+			"classConstructorData": {
+				"parameters": [
+					{
+						"name": "bucket",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "Bucket"
+					},
+					{
+						"name": "name",
+						"optional": false,
+						"type": "StringKeyword",
+						"typeRefName": null
+					},
+					{
+						"name": "options",
+						"optional": true,
+						"type": "TypeReference",
+						"typeRefName": "FileOptions"
+					}
+				]
+			}
+		}
+	],
+	"classData": [
+		{
+			"name": "AclRoleAccessorMethods",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "_assignAccessMethods",
+					"params": [
+						{
+							"name": "role",
+							"optional": false,
+							"type": "StringKeyword"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "AclRoleAccessorMethods"
+				}
+			],
+			"properties": [
+				{
+					"name": "owners",
+					"type": "TypeLiteral",
+					"typeRefName": null
+				},
+				{
+					"name": "readers",
+					"type": "TypeLiteral",
+					"typeRefName": null
+				},
+				{
+					"name": "writers",
+					"type": "TypeLiteral",
+					"typeRefName": null
+				}
+			],
+			"constructor": {
+				"parameters": []
+			}
+		},
+		{
+			"name": "Acl",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "add",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "add",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "delete",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "delete",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "get",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "get",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "get",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "update",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "update",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makeAclObject_",
+					"params": [
+						{
+							"name": "accessControlObject",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "AccessControlObject",
+					"client": "Acl"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "acl.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "request",
+					"params": [
+						{
+							"name": "reqOpts",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Acl"
+				}
+			],
+			"properties": [
+				{
+					"name": "default",
+					"type": "TypeReference",
+					"typeRefName": "Acl"
+				},
+				{
+					"name": "pathPrefix",
+					"type": "StringKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "request_",
+					"type": "FunctionType",
+					"typeRefName": null
+				}
+			],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "options",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "AclOptions"
+					}
+				]
+			}
+		},
+		{
+			"name": "Bucket",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "addLifecycleRule",
+					"params": [
+						{
+							"name": "rule",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "addLifecycleRule",
+					"params": [
+						{
+							"name": "rule",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "addLifecycleRule",
+					"params": [
+						{
+							"name": "rule",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "combine",
+					"params": [
+						{
+							"name": "sources",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "combine",
+					"params": [
+						{
+							"name": "sources",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "combine",
+					"params": [
+						{
+							"name": "sources",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createChannel",
+					"params": [
+						{
+							"name": "id",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "config",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createChannel",
+					"params": [
+						{
+							"name": "id",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "config",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createChannel",
+					"params": [
+						{
+							"name": "id",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "config",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createNotification",
+					"params": [
+						{
+							"name": "topic",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createNotification",
+					"params": [
+						{
+							"name": "topic",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createNotification",
+					"params": [
+						{
+							"name": "topic",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "deleteFiles",
+					"params": [
+						{
+							"name": "query",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "deleteFiles",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "deleteFiles",
+					"params": [
+						{
+							"name": "query",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "deleteLabels",
+					"params": [
+						{
+							"name": "labels",
+							"optional": true,
+							"type": "UnionType"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "deleteLabels",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "deleteLabels",
+					"params": [
+						{
+							"name": "labels",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "disableRequesterPays",
+					"params": [],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "disableRequesterPays",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "enableLogging",
+					"params": [
+						{
+							"name": "config",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "enableLogging",
+					"params": [
+						{
+							"name": "config",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "enableRequesterPays",
+					"params": [],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "enableRequesterPays",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "file",
+					"params": [
+						{
+							"name": "name",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "File",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getFiles",
+					"params": [
+						{
+							"name": "query",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getFiles",
+					"params": [
+						{
+							"name": "query",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getFiles",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getLabels",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getLabels",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getLabels",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getNotifications",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getNotifications",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getNotifications",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedUrl",
+					"params": [
+						{
+							"name": "cfg",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedUrl",
+					"params": [
+						{
+							"name": "cfg",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "lock",
+					"params": [
+						{
+							"name": "metageneration",
+							"optional": false,
+							"type": "UnionType"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "lock",
+					"params": [
+						{
+							"name": "metageneration",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePrivate",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePrivate",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePrivate",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePublic",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePublic",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePublic",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "notification",
+					"params": [
+						{
+							"name": "id",
+							"optional": false,
+							"type": "StringKeyword"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Notification",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "removeRetentionPeriod",
+					"params": [],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "removeRetentionPeriod",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "request",
+					"params": [
+						{
+							"name": "reqOpts",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "request",
+					"params": [
+						{
+							"name": "reqOpts",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setLabels",
+					"params": [
+						{
+							"name": "labels",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setLabels",
+					"params": [
+						{
+							"name": "labels",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setLabels",
+					"params": [
+						{
+							"name": "labels",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setRetentionPeriod",
+					"params": [
+						{
+							"name": "duration",
+							"optional": false,
+							"type": "NumberKeyword"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setRetentionPeriod",
+					"params": [
+						{
+							"name": "duration",
+							"optional": false,
+							"type": "NumberKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setCorsConfiguration",
+					"params": [
+						{
+							"name": "corsConfiguration",
+							"optional": false,
+							"type": "ArrayType"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setCorsConfiguration",
+					"params": [
+						{
+							"name": "corsConfiguration",
+							"optional": false,
+							"type": "ArrayType"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setStorageClass",
+					"params": [
+						{
+							"name": "storageClass",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setStorageClass",
+					"params": [
+						{
+							"name": "storageClass",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setStorageClass",
+					"params": [
+						{
+							"name": "storageClass",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setUserProject",
+					"params": [
+						{
+							"name": "userProject",
+							"optional": false,
+							"type": "StringKeyword"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "upload",
+					"params": [
+						{
+							"name": "pathString",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "upload",
+					"params": [
+						{
+							"name": "pathString",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "upload",
+					"params": [
+						{
+							"name": "pathString",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makeAllFilesPublicPrivate_",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makeAllFilesPublicPrivate_",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makeAllFilesPublicPrivate_",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "bucket.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getId",
+					"params": [],
+					"returnType": "StringKeyword",
+					"returnTypeName": null,
+					"client": "Bucket"
+				}
+			],
+			"properties": [
+				{
+					"name": "name",
+					"type": "StringKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "storage",
+					"type": "TypeReference",
+					"typeRefName": "Storage"
+				},
+				{
+					"name": "userProject",
+					"type": "StringKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "acl",
+					"type": "TypeReference",
+					"typeRefName": "Acl"
+				},
+				{
+					"name": "iam",
+					"type": "TypeReference",
+					"typeRefName": "Iam"
+				},
+				{
+					"name": "getFilesStream",
+					"type": "TypeReference",
+					"typeRefName": "Function"
+				},
+				{
+					"name": "signer",
+					"type": "TypeReference",
+					"typeRefName": "URLSigner"
+				}
+			],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "storage",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "Storage"
+					},
+					{
+						"name": "name",
+						"optional": false,
+						"type": "StringKeyword",
+						"typeRefName": null
+					},
+					{
+						"name": "options",
+						"optional": true,
+						"type": "TypeReference",
+						"typeRefName": "BucketOptions"
+					}
+				]
+			}
+		},
+		{
+			"name": "Channel",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "channel.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "stop",
+					"params": [],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Channel"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "channel.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "stop",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Channel"
+				}
+			],
+			"properties": [],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "storage",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "Storage"
+					},
+					{
+						"name": "id",
+						"optional": false,
+						"type": "StringKeyword",
+						"typeRefName": null
+					},
+					{
+						"name": "resourceId",
+						"optional": false,
+						"type": "StringKeyword",
+						"typeRefName": null
+					}
+				]
+			}
+		},
+		{
+			"name": "RequestError",
+			"methods": [],
+			"properties": [
+				{
+					"name": "code",
+					"type": "StringKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "errors",
+					"type": "ArrayType",
+					"typeRefName": null
+				}
+			],
+			"constructor": null
+		},
+		{
+			"name": "File",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "copy",
+					"params": [
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "copy",
+					"params": [
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "copy",
+					"params": [
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createReadStream",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Readable",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createResumableUpload",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createResumableUpload",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createResumableUpload",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createWriteStream",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Writable",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "deleteResumableCache",
+					"params": [],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "download",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "download",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "download",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setEncryptionKey",
+					"params": [
+						{
+							"name": "encryptionKey",
+							"optional": false,
+							"type": "UnionType"
+						}
+					],
+					"returnType": "ThisType",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getExpirationDate",
+					"params": [],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getExpirationDate",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedPolicy",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedPolicy",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedPolicy",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "generateSignedPostPolicyV2",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "generateSignedPostPolicyV2",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "generateSignedPostPolicyV2",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "generateSignedPostPolicyV4",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "generateSignedPostPolicyV4",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "generateSignedPostPolicyV4",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedUrl",
+					"params": [
+						{
+							"name": "cfg",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedUrl",
+					"params": [
+						{
+							"name": "cfg",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "isPublic",
+					"params": [],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "isPublic",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePrivate",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePrivate",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "makePrivate",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": "makePublic",
+					"SDKFunctionName": "makePublic",
+					"params": [],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File",
+					"classConstructorData": {
+						"parameters": [
+							{
+								"name": "bucket",
+								"optional": false,
+								"type": "TypeReference",
+								"typeRefName": "Bucket"
+							},
+							{
+								"name": "name",
+								"optional": false,
+								"type": "StringKeyword",
+								"typeRefName": null
+							},
+							{
+								"name": "options",
+								"optional": true,
+								"type": "TypeReference",
+								"typeRefName": "FileOptions"
+							}
+						]
+					}
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": "makePublic",
+					"SDKFunctionName": "makePublic",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File",
+					"classConstructorData": {
+						"parameters": [
+							{
+								"name": "bucket",
+								"optional": false,
+								"type": "TypeReference",
+								"typeRefName": "Bucket"
+							},
+							{
+								"name": "name",
+								"optional": false,
+								"type": "StringKeyword",
+								"typeRefName": null
+							},
+							{
+								"name": "options",
+								"optional": true,
+								"type": "TypeReference",
+								"typeRefName": "FileOptions"
+							}
+						]
+					}
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "move",
+					"params": [
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "move",
+					"params": [
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "move",
+					"params": [
+						{
+							"name": "destination",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "request",
+					"params": [
+						{
+							"name": "reqOpts",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "request",
+					"params": [
+						{
+							"name": "reqOpts",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "rotateEncryptionKey",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "rotateEncryptionKey",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "rotateEncryptionKey",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "save",
+					"params": [
+						{
+							"name": "data",
+							"optional": false,
+							"type": "AnyKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "save",
+					"params": [
+						{
+							"name": "data",
+							"optional": false,
+							"type": "AnyKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "save",
+					"params": [
+						{
+							"name": "data",
+							"optional": false,
+							"type": "AnyKeyword"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setStorageClass",
+					"params": [
+						{
+							"name": "storageClass",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setStorageClass",
+					"params": [
+						{
+							"name": "storageClass",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setStorageClass",
+					"params": [
+						{
+							"name": "storageClass",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setUserProject",
+					"params": [
+						{
+							"name": "userProject",
+							"optional": false,
+							"type": "StringKeyword"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "startResumableUpload_",
+					"params": [
+						{
+							"name": "dup",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "file.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "startSimpleUpload_",
+					"params": [
+						{
+							"name": "dup",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "File"
+				}
+			],
+			"properties": [
+				{
+					"name": "acl",
+					"type": "TypeReference",
+					"typeRefName": "Acl"
+				},
+				{
+					"name": "bucket",
+					"type": "TypeReference",
+					"typeRefName": "Bucket"
+				},
+				{
+					"name": "storage",
+					"type": "TypeReference",
+					"typeRefName": "Storage"
+				},
+				{
+					"name": "kmsKeyName",
+					"type": "StringKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "userProject",
+					"type": "StringKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "signer",
+					"type": "TypeReference",
+					"typeRefName": "URLSigner"
+				},
+				{
+					"name": "name",
+					"type": "StringKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "generation",
+					"type": "NumberKeyword",
+					"typeRefName": null
+				},
+				{
+					"name": "parent",
+					"type": "TypeReference",
+					"typeRefName": "Bucket"
+				}
+			],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "bucket",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "Bucket"
+					},
+					{
+						"name": "name",
+						"optional": false,
+						"type": "StringKeyword",
+						"typeRefName": null
+					},
+					{
+						"name": "options",
+						"optional": true,
+						"type": "TypeReference",
+						"typeRefName": "FileOptions"
+					}
+				]
+			}
+		},
+		{
+			"name": "HmacKey",
+			"methods": [],
+			"properties": [
+				{
+					"name": "metadata",
+					"type": "UnionType",
+					"typeRefName": null
+				}
+			],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "storage",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "Storage"
+					},
+					{
+						"name": "accessId",
+						"optional": false,
+						"type": "StringKeyword",
+						"typeRefName": null
+					},
+					{
+						"name": "options",
+						"optional": true,
+						"type": "TypeReference",
+						"typeRefName": "HmacKeyOptions"
+					}
+				]
+			}
+		},
+		{
+			"name": "Iam",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getPolicy",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getPolicy",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getPolicy",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setPolicy",
+					"params": [
+						{
+							"name": "policy",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setPolicy",
+					"params": [
+						{
+							"name": "policy",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "setPolicy",
+					"params": [
+						{
+							"name": "policy",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "testPermissions",
+					"params": [
+						{
+							"name": "permissions",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "testPermissions",
+					"params": [
+						{
+							"name": "permissions",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Iam"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "iam.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "testPermissions",
+					"params": [
+						{
+							"name": "permissions",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Iam"
+				}
+			],
+			"properties": [],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "bucket",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "Bucket"
+					}
+				]
+			}
+		},
+		{
+			"name": "Notification",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "delete",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "delete",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "delete",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "get",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "get",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "get",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getMetadata",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getMetadata",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Notification"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "notification.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getMetadata",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Notification"
+				}
+			],
+			"properties": [],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "bucket",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "Bucket"
+					},
+					{
+						"name": "id",
+						"optional": false,
+						"type": "StringKeyword",
+						"typeRefName": null
+					}
+				]
+			}
+		},
+		{
+			"name": "URLSigner",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "signer.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getSignedUrl",
+					"params": [
+						{
+							"name": "cfg",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "URLSigner"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "signer.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getCanonicalHeaders",
+					"params": [
+						{
+							"name": "headers",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "StringKeyword",
+					"returnTypeName": null,
+					"client": "URLSigner"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "signer.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getCanonicalRequest",
+					"params": [
+						{
+							"name": "method",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "path",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "query",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "headers",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "signedHeaders",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "contentSha256",
+							"optional": true,
+							"type": "StringKeyword"
+						}
+					],
+					"returnType": "StringKeyword",
+					"returnTypeName": null,
+					"client": "URLSigner"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "signer.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getCanonicalQueryParams",
+					"params": [
+						{
+							"name": "query",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "StringKeyword",
+					"returnTypeName": null,
+					"client": "URLSigner"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "signer.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getResourcePath",
+					"params": [
+						{
+							"name": "cname",
+							"optional": false,
+							"type": "BooleanKeyword"
+						},
+						{
+							"name": "bucket",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "file",
+							"optional": true,
+							"type": "StringKeyword"
+						}
+					],
+					"returnType": "StringKeyword",
+					"returnTypeName": null,
+					"client": "URLSigner"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "signer.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "parseExpires",
+					"params": [
+						{
+							"name": "expires",
+							"optional": false,
+							"type": "UnionType"
+						},
+						{
+							"name": "current",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "NumberKeyword",
+					"returnTypeName": null,
+					"client": "URLSigner"
+				}
+			],
+			"properties": [],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "authClient",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "AuthClient"
+					},
+					{
+						"name": "bucket",
+						"optional": false,
+						"type": "TypeReference",
+						"typeRefName": "BucketI"
+					},
+					{
+						"name": "file",
+						"optional": true,
+						"type": "TypeReference",
+						"typeRefName": "FileI"
+					}
+				]
+			}
+		},
+		{
+			"name": "SigningError",
+			"methods": [],
+			"properties": [
+				{
+					"name": "name",
+					"type": "StringKeyword",
+					"typeRefName": null
+				}
+			],
+			"constructor": null
+		},
+		{
+			"name": "Storage",
+			"methods": [
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "bucket",
+					"params": [
+						{
+							"name": "name",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Bucket",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "channel",
+					"params": [
+						{
+							"name": "id",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "resourceId",
+							"optional": false,
+							"type": "StringKeyword"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Channel",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createBucket",
+					"params": [
+						{
+							"name": "name",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "metadata",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createBucket",
+					"params": [
+						{
+							"name": "name",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createBucket",
+					"params": [
+						{
+							"name": "name",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "metadata",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createBucket",
+					"params": [
+						{
+							"name": "name",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "metadata",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createHmacKey",
+					"params": [
+						{
+							"name": "serviceAccountEmail",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createHmacKey",
+					"params": [
+						{
+							"name": "serviceAccountEmail",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "createHmacKey",
+					"params": [
+						{
+							"name": "serviceAccountEmail",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getBuckets",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getBuckets",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getBuckets",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getHmacKeys",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getHmacKeys",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getHmacKeys",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getServiceAccount",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getServiceAccount",
+					"params": [
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "Promise",
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getServiceAccount",
+					"params": [
+						{
+							"name": "options",
+							"optional": false,
+							"type": "TypeReference"
+						},
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "getServiceAccount",
+					"params": [
+						{
+							"name": "callback",
+							"optional": false,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "VoidKeyword",
+					"returnTypeName": null,
+					"client": "Storage"
+				},
+				{
+					"pkgName": "storage",
+					"version": null,
+					"fileName": "storage.d.ts",
+					"functionName": null,
+					"SDKFunctionName": "hmacKey",
+					"params": [
+						{
+							"name": "accessId",
+							"optional": false,
+							"type": "StringKeyword"
+						},
+						{
+							"name": "options",
+							"optional": true,
+							"type": "TypeReference"
+						}
+					],
+					"returnType": "TypeReference",
+					"returnTypeName": "HmacKey",
+					"client": "Storage"
+				}
+			],
+			"properties": [
+				{
+					"name": "Bucket",
+					"type": "TypeQuery",
+					"typeRefName": null
+				},
+				{
+					"name": "Channel",
+					"type": "TypeQuery",
+					"typeRefName": null
+				},
+				{
+					"name": "File",
+					"type": "TypeQuery",
+					"typeRefName": null
+				},
+				{
+					"name": "HmacKey",
+					"type": "TypeQuery",
+					"typeRefName": null
+				},
+				{
+					"name": "acl",
+					"type": "TypeLiteral",
+					"typeRefName": null
+				},
+				{
+					"name": "acl",
+					"type": "TypeQuery",
+					"typeRefName": null
+				},
+				{
+					"name": "getBucketsStream",
+					"type": "FunctionType",
+					"typeRefName": null
+				},
+				{
+					"name": "getHmacKeysStream",
+					"type": "FunctionType",
+					"typeRefName": null
+				}
+			],
+			"constructor": {
+				"parameters": [
+					{
+						"name": "options",
+						"optional": true,
+						"type": "TypeReference",
+						"typeRefName": "StorageOptions"
+					}
+				]
+			}
+		}
+	]
 }

--- a/generator/test/transformers/googleCloud/dummyData/clientBasedTransformer/invalidDataset_1/data.json
+++ b/generator/test/transformers/googleCloud/dummyData/clientBasedTransformer/invalidDataset_1/data.json
@@ -1,124 +1,124 @@
 {
-  "functions": [
-    {
-      "functionName": "create",
-      "SDKFunctionName": "createOrUpdate",
-      "params": [
-        {
-          "name": "resourceGroupName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "resourceName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "parameters",
-          "optional": false,
-          "type": "TypeReference"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    },
-    {
-      "functionName": "delete",
-      "SDKFunctionName": "deleteMethod",
-      "params": [
-        {
-          "name": "resourceGroupName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "resourceName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    },
-    {
-      "functionName": "updateTags",
-      "SDKFunctionName": "updateTags",
-      "params": [
-        {
-          "name": "resourceGroupName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "resourceName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "parameters",
-          "optional": false,
-          "type": "TypeReference"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    },
-    {
-      "functionName": "listByResourceGroup",
-      "SDKFunctionName": "listByResourceGroup",
-      "params": [
-        {
-          "name": "resourceGroupName",
-          "optional": false,
-          "type": "StringKeyword"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    },
-    {
-      "functionName": "listClusters",
-      "SDKFunctionName": "list",
-      "params": [
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "arm-containerservice",
-      "fileName": "managedClusters.d.ts",
-      "client": "ContainerServiceClient",
-      "returnType": "TypeReference"
-    }
-  ]
+	"functions": [
+		{
+			"functionName": "create",
+			"SDKFunctionName": "createOrUpdate",
+			"params": [
+				{
+					"name": "resourceGroupName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "resourceName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "parameters",
+					"optional": false,
+					"type": "TypeReference"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		},
+		{
+			"functionName": "delete",
+			"SDKFunctionName": "deleteMethod",
+			"params": [
+				{
+					"name": "resourceGroupName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "resourceName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		},
+		{
+			"functionName": "updateTags",
+			"SDKFunctionName": "updateTags",
+			"params": [
+				{
+					"name": "resourceGroupName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "resourceName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "parameters",
+					"optional": false,
+					"type": "TypeReference"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		},
+		{
+			"functionName": "listByResourceGroup",
+			"SDKFunctionName": "listByResourceGroup",
+			"params": [
+				{
+					"name": "resourceGroupName",
+					"optional": false,
+					"type": "StringKeyword"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		},
+		{
+			"functionName": "listClusters",
+			"SDKFunctionName": "list",
+			"params": [
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "arm-containerservice",
+			"fileName": "managedClusters.d.ts",
+			"client": "ContainerServiceClient",
+			"returnType": "TypeReference"
+		}
+	]
 }

--- a/generator/test/transformers/googleCloud/dummyData/clientBasedTransformer/validDataset/data.json
+++ b/generator/test/transformers/googleCloud/dummyData/clientBasedTransformer/validDataset/data.json
@@ -1,125 +1,125 @@
 {
-  "functions": [
-    {
-      "functionName": "createAlarm",
-      "SDKFunctionName": "createAlertPolicy",
-      "params": [
-        {
-          "name": "request",
-          "optional": false,
-          "type": "TypeReference"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "monitoring",
-      "fileName": "alert_policy_service_client.d.ts",
-      "client": "AlertPolicyServiceClient",
-      "returnType": "TypeReference",
-      "returnTypeName": "Promise"
-    },
-    {
-      "functionName": "deleteAlarm",
-      "SDKFunctionName": "deleteAlertPolicy",
-      "params": [
-        {
-          "name": "request",
-          "optional": false,
-          "type": "TypeReference"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "monitoring",
-      "fileName": "alert_policy_service_client.d.ts",
-      "client": "AlertPolicyServiceClient",
-      "returnType": "TypeReference",
-      "returnTypeName": "Promise"
-    },
-    {
-      "functionName": "updateAlarm",
-      "SDKFunctionName": "updateAlertPolicy",
-      "params": [
-        {
-          "name": "request",
-          "optional": false,
-          "type": "TypeReference"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "monitoring",
-      "fileName": "alert_policy_service_client.d.ts",
-      "client": "AlertPolicyServiceClient",
-      "returnType": "TypeReference",
-      "returnTypeName": "Promise"
-    },
-    {
-      "functionName": "listAlarms",
-      "SDKFunctionName": "listAlertPolicies",
-      "params": [
-        {
-          "name": "request",
-          "optional": false,
-          "type": "TypeReference"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "monitoring",
-      "fileName": "alert_policy_service_client.d.ts",
-      "client": "AlertPolicyServiceClient",
-      "returnType": "TypeReference",
-      "returnTypeName": "Promise"
-    },
-    {
-      "functionName": "getMetricDescriptor",
-      "SDKFunctionName": "getMetricDescriptor",
-      "params": [
-        {
-          "name": "request",
-          "optional": false,
-          "type": "TypeReference"
-        },
-        {
-          "name": "options",
-          "optional": true,
-          "type": "TypeReference"
-        }
-      ],
-      "pkgName": "monitoring",
-      "fileName": "metric_service_client.d.ts",
-      "client": "MetricServiceClient",
-      "returnType": "TypeReference",
-      "returnTypeName": "Promise"
-    },
-    {
-      "functionName": "projectPath",
-      "SDKFunctionName": "projectPath",
-      "params": [
-        {
-          "name": "project",
-          "optional": false,
-          "type": "StringKeyword"
-        }
-      ],
-      "pkgName": "monitoring",
-      "fileName": "alert_policy_service_client.d.ts",
-      "client": "AlertPolicyServiceClient",
-      "returnType": "StringKeyword",
-      "returnTypeName": null
-    }
-  ]
+	"functions": [
+		{
+			"functionName": "createAlarm",
+			"SDKFunctionName": "createAlertPolicy",
+			"params": [
+				{
+					"name": "request",
+					"optional": false,
+					"type": "TypeReference"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "monitoring",
+			"fileName": "alert_policy_service_client.d.ts",
+			"client": "AlertPolicyServiceClient",
+			"returnType": "TypeReference",
+			"returnTypeName": "Promise"
+		},
+		{
+			"functionName": "deleteAlarm",
+			"SDKFunctionName": "deleteAlertPolicy",
+			"params": [
+				{
+					"name": "request",
+					"optional": false,
+					"type": "TypeReference"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "monitoring",
+			"fileName": "alert_policy_service_client.d.ts",
+			"client": "AlertPolicyServiceClient",
+			"returnType": "TypeReference",
+			"returnTypeName": "Promise"
+		},
+		{
+			"functionName": "updateAlarm",
+			"SDKFunctionName": "updateAlertPolicy",
+			"params": [
+				{
+					"name": "request",
+					"optional": false,
+					"type": "TypeReference"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "monitoring",
+			"fileName": "alert_policy_service_client.d.ts",
+			"client": "AlertPolicyServiceClient",
+			"returnType": "TypeReference",
+			"returnTypeName": "Promise"
+		},
+		{
+			"functionName": "listAlarms",
+			"SDKFunctionName": "listAlertPolicies",
+			"params": [
+				{
+					"name": "request",
+					"optional": false,
+					"type": "TypeReference"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "monitoring",
+			"fileName": "alert_policy_service_client.d.ts",
+			"client": "AlertPolicyServiceClient",
+			"returnType": "TypeReference",
+			"returnTypeName": "Promise"
+		},
+		{
+			"functionName": "getMetricDescriptor",
+			"SDKFunctionName": "getMetricDescriptor",
+			"params": [
+				{
+					"name": "request",
+					"optional": false,
+					"type": "TypeReference"
+				},
+				{
+					"name": "options",
+					"optional": true,
+					"type": "TypeReference"
+				}
+			],
+			"pkgName": "monitoring",
+			"fileName": "metric_service_client.d.ts",
+			"client": "MetricServiceClient",
+			"returnType": "TypeReference",
+			"returnTypeName": "Promise"
+		},
+		{
+			"functionName": "projectPath",
+			"SDKFunctionName": "projectPath",
+			"params": [
+				{
+					"name": "project",
+					"optional": false,
+					"type": "StringKeyword"
+				}
+			],
+			"pkgName": "monitoring",
+			"fileName": "alert_policy_service_client.d.ts",
+			"client": "AlertPolicyServiceClient",
+			"returnType": "StringKeyword",
+			"returnTypeName": null
+		}
+	]
 }

--- a/generator/test/transformers/lib/helper.ts
+++ b/generator/test/transformers/lib/helper.ts
@@ -1,35 +1,35 @@
-import * as fs from "fs";
-import { createSourceFile,ScriptTarget } from "typescript";
+import * as fs from 'fs';
+import { createSourceFile, ScriptTarget } from 'typescript';
 
 export function readSourceFile(datasetName, provider) {
-  return new Promise((resolve, reject) => {
-    try {
-      const testFile =
-        process.cwd() +
-        `/test/transformers/${provider}/dummyData/${datasetName}/sourceFile.js`;
-      const testAST = createSourceFile(
-        testFile,
-        fs.readFileSync(testFile).toString(),
-        ScriptTarget.Latest,
-        true
-      );
-      resolve(testAST);
-    } catch (error) {
-      console.error(error);
-    }
-  });
+	return new Promise((resolve, reject) => {
+		try {
+			const testFile =
+				process.cwd() +
+				`/test/transformers/${provider}/dummyData/${datasetName}/sourceFile.js`;
+			const testAST = createSourceFile(
+				testFile,
+				fs.readFileSync(testFile).toString(),
+				ScriptTarget.Latest,
+				true
+			);
+			resolve(testAST);
+		} catch (error) {
+			console.error(error);
+		}
+	});
 }
 
 export function readJsonData(datasetName, provider) {
-  return new Promise((resolve, reject) => {
-    try {
-      const testFile =
-        process.cwd() +
-        `/test/transformers/${provider}/dummyData/${datasetName}/data.json`;
-      const testData = JSON.parse(fs.readFileSync(testFile, "utf8"));
-      resolve(testData);
-    } catch (error) {
-      console.error(error);
-    }
-  });
+	return new Promise((resolve, reject) => {
+		try {
+			const testFile =
+				process.cwd() +
+				`/test/transformers/${provider}/dummyData/${datasetName}/data.json`;
+			const testData = JSON.parse(fs.readFileSync(testFile, 'utf8'));
+			resolve(testData);
+		} catch (error) {
+			console.error(error);
+		}
+	});
 }

--- a/generator/transformers/aws/transformer.ts
+++ b/generator/transformers/aws/transformer.ts
@@ -1,239 +1,252 @@
-import { cloneDeep } from "lodash";
-import * as ts from "typescript";
+import { cloneDeep } from 'lodash';
+import * as ts from 'typescript';
 
 const dummyIdentifiers = [
-  "ClassName",
-  "_sdkClassName",
-  "SDKClassName",
-  "SDKFunctionName"
+	'ClassName',
+	'_sdkClassName',
+	'SDKClassName',
+	'SDKFunctionName',
 ];
 
 const printer: ts.Printer = ts.createPrinter({
-  newLine: ts.NewLineKind.LineFeed,
-  removeComments: false
+	newLine: ts.NewLineKind.LineFeed,
+	removeComments: false,
 });
 
 function addMultiLineComment(node, comment: string) {
-  ts.addSyntheticLeadingComment(
-    node,
-    ts.SyntaxKind.MultiLineCommentTrivia,
-    comment,
-    true
-  );
+	ts.addSyntheticLeadingComment(
+		node,
+		ts.SyntaxKind.MultiLineCommentTrivia,
+		comment,
+		true
+	);
 }
 
 function runTransformation(sourceCode, transformMethod): Promise<string> {
-  return new Promise((resolve, reject) => {
-    try {
-      const result = ts.transform(sourceCode, [transformMethod]);
-      const transformedNodes = result.transformed[0];
-      const output = printer.printNode(
-        ts.EmitHint.SourceFile,
-        transformedNodes,
-        sourceCode
-      );
-      resolve(output);
-    } catch (error) {
-      reject(error);
-    }
-  });
+	return new Promise((resolve, reject) => {
+		try {
+			const result = ts.transform(sourceCode, [transformMethod]);
+			const transformedNodes = result.transformed[0];
+			const output = printer.printNode(
+				ts.EmitHint.SourceFile,
+				transformedNodes,
+				sourceCode
+			);
+			resolve(output);
+		} catch (error) {
+			reject(error);
+		}
+	});
 }
 
 function toSourceFile(sourceCode: string): ts.SourceFile {
-  return ts.createSourceFile(
-    "dummyClass.js",
-    sourceCode,
-    ts.ScriptTarget.Latest,
-    true
-  );
+	return ts.createSourceFile(
+		'dummyClass.js',
+		sourceCode,
+		ts.ScriptTarget.Latest,
+		true
+	);
 }
 
 export async function transform(
-  code: ts.SourceFile,
-  classData: any
+	code: ts.SourceFile,
+	classData: any
 ): Promise<string> {
-  const addFunctions = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isClassDeclaration(node)) {
-        let functions: any = [];
-        classData.functions.map(method => {
-          const clonedNode = Object.assign({}, node.members[1]);
-          clonedNode.name = ts.createIdentifier(method.functionName);
-          functions.push(clonedNode);
-        });
+	const addFunctions = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isClassDeclaration(node)) {
+				let functions: any = [];
+				classData.functions.map(method => {
+					const clonedNode = Object.assign({}, node.members[1]);
+					clonedNode.name = ts.createIdentifier(method.functionName);
+					functions.push(clonedNode);
+				});
 
-        const updatedClass = ts.updateClassDeclaration(
-          node,
-          node.decorators,
-          node.modifiers,
-          node.name,
-          node.typeParameters,
-          node.heritageClauses,
-          ts.createNodeArray([node.members[0]].concat(functions))
-        );
+				const updatedClass = ts.updateClassDeclaration(
+					node,
+					node.decorators,
+					node.modifiers,
+					node.name,
+					node.typeParameters,
+					node.heritageClauses,
+					ts.createNodeArray([node.members[0]].concat(functions))
+				);
 
-        return updatedClass;
-      }
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+				return updatedClass;
+			}
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  const addIdentifiers = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    let count = 0;
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isMethodDeclaration(node)) {
-        const parameters = classData.functions[count].params.map(param => {
-          const paramNode = ts.createParameter(
-            undefined,
-            undefined,
-            undefined,
-            param.name
-          );
+	const addIdentifiers = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		let count = 0;
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isMethodDeclaration(node)) {
+				const parameters = classData.functions[count].params.map(
+					param => {
+						const paramNode = ts.createParameter(
+							undefined,
+							undefined,
+							undefined,
+							param.name
+						);
 
-          if (param.optional) {
-            paramNode.initializer = ts.createIdentifier("undefined");
-          }
+						if (param.optional) {
+							paramNode.initializer = ts.createIdentifier(
+								'undefined'
+							);
+						}
 
-          return paramNode;
-        });
+						return paramNode;
+					}
+				);
 
-        node.parameters = parameters;
-      }
+				node.parameters = parameters;
+			}
 
-      if (ts.isIdentifier(node) && dummyIdentifiers.includes(node.text)) {
-        let updatedIdentifier;
+			if (ts.isIdentifier(node) && dummyIdentifiers.includes(node.text)) {
+				let updatedIdentifier;
 
-        switch (node.text) {
-          case "ClassName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier("AWS_" + classData.serviceName)
-            );
-            break;
-          case "_sdkClassName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(
-                "_" +
-                  classData.className.charAt(0).toLowerCase() +
-                  classData.className.substr(1)
-              )
-            );
-            break;
-          case "SDKClassName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(classData.className)
-            );
-            break;
-          case "SDKFunctionName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(classData.functions[count].SDKFunctionName)
-            );
-            count++;
-        }
+				switch (node.text) {
+					case 'ClassName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier('AWS_' + classData.serviceName)
+						);
+						break;
+					case '_sdkClassName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								'_' +
+									classData.className
+										.charAt(0)
+										.toLowerCase() +
+									classData.className.substr(1)
+							)
+						);
+						break;
+					case 'SDKClassName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(classData.className)
+						);
+						break;
+					case 'SDKFunctionName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								classData.functions[count].SDKFunctionName
+							)
+						);
+						count++;
+				}
 
-        return updatedIdentifier;
-      }
+				return updatedIdentifier;
+			}
 
-      if (ts.isCallExpression(node)) {
-        node.expression.forEachChild(childNode => {
-          if (
-            ts.isIdentifier(childNode) &&
-            childNode.text === "SDKFunctionName"
-          ) {
-            const args = classData.functions[count].params.map(param =>
-              ts.createIdentifier(param.name)
-            );
-            node.arguments = args.concat(node.arguments);
-          }
-        });
-      }
+			if (ts.isCallExpression(node)) {
+				node.expression.forEachChild(childNode => {
+					if (
+						ts.isIdentifier(childNode) &&
+						childNode.text === 'SDKFunctionName'
+					) {
+						const args = classData.functions[count].params.map(
+							param => ts.createIdentifier(param.name)
+						);
+						node.arguments = args.concat(node.arguments);
+					}
+				});
+			}
 
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  const addComments = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    let count = 0;
+	const addComments = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		let count = 0;
 
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isClassDeclaration(node)) {
-        addMultiLineComment(
-          node,
-          "This is an auto generated class, please do not change."
-        );
-        const comment = `*
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isClassDeclaration(node)) {
+				addMultiLineComment(
+					node,
+					'This is an auto generated class, please do not change.'
+				);
+				const comment = `*
  * Class to create a ${classData.className} object
  * @category AWS       
  `;
-        addMultiLineComment(node, comment);
-      }
+				addMultiLineComment(node, comment);
+			}
 
-      if (ts.isMethodDeclaration(node)) {
-        let parameters = classData.functions[count].params.map(param => {
-          let statment;
+			if (ts.isMethodDeclaration(node)) {
+				let parameters = classData.functions[count].params.map(
+					param => {
+						let statment;
 
-          if (param.optional) {
-            statment = `* @param {${param.typeName}} [${param.name}] - Data required for ${classData.functions[count].SDKFunctionName}`;
-          } else {
-            statment = `* @param {${param.typeName}} ${param.name} - Data required for ${classData.functions[count].SDKFunctionName}`;
-          }
-          return statment;
-        });
+						if (param.optional) {
+							statment = `* @param {${param.typeName}} [${param.name}] - Data required for ${classData.functions[count].SDKFunctionName}`;
+						} else {
+							statment = `* @param {${param.typeName}} ${param.name} - Data required for ${classData.functions[count].SDKFunctionName}`;
+						}
+						return statment;
+					}
+				);
 
-        let comment;
-        if (parameters.length > 0) {
-          let paramStatments: string = "";
-          parameters.map(param => {
-            paramStatments = paramStatments.concat(
-              paramStatments === "" ? `${param}` : `\n ${param}`
-            );
-          });
+				let comment;
+				if (parameters.length > 0) {
+					let paramStatments: string = '';
+					parameters.map(param => {
+						paramStatments = paramStatments.concat(
+							paramStatments === '' ? `${param}` : `\n ${param}`
+						);
+					});
 
-          comment = `*
+					comment = `*
  * Trigers the ${classData.functions[count].SDKFunctionName} function of ${classData.className}
  ${paramStatments}
  * @returns {Promise<${classData.functions[count].SDKFunctionName}Response>}
  `;
-        } else {
-          comment = `*
+				} else {
+					comment = `*
  * Trigers the ${classData.functions[count].SDKFunctionName} function of ${classData.className}
  * @returns {Promise<${classData.functions[count].SDKFunctionName}Response>}
  `;
-        }
+				}
 
-        addMultiLineComment(node, comment);
-        count++;
-      }
+				addMultiLineComment(node, comment);
+				count++;
+			}
 
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  const node: any = code.statements.find(stm => ts.isClassDeclaration(stm));
+	const node: any = code.statements.find(stm => ts.isClassDeclaration(stm));
 
-  if (!classData.className || !classData.functions) {
-    throw new Error("Input is invalid");
-  }
+	if (!classData.className || !classData.functions) {
+		throw new Error('Input is invalid');
+	}
 
-  if (!node || !node.members.some(member => ts.isMethodDeclaration(member))) {
-    throw new Error("Code is invalid");
-  }
+	if (!node || !node.members.some(member => ts.isMethodDeclaration(member))) {
+		throw new Error('Code is invalid');
+	}
 
-  code = cloneDeep(code);
+	code = cloneDeep(code);
 
-  const result_1 = await runTransformation(code, addFunctions);
-  const result_2 = await runTransformation(
-    toSourceFile(result_1),
-    addIdentifiers
-  );
-  const result_3 = await runTransformation(toSourceFile(result_2), addComments);
-  return result_3;
+	const result_1 = await runTransformation(code, addFunctions);
+	const result_2 = await runTransformation(
+		toSourceFile(result_1),
+		addIdentifiers
+	);
+	const result_3 = await runTransformation(
+		toSourceFile(result_2),
+		addComments
+	);
+	return result_3;
 }

--- a/generator/transformers/azure/transformer.ts
+++ b/generator/transformers/azure/transformer.ts
@@ -1,262 +1,279 @@
-import { cloneDeep } from "lodash";
-import * as ts from "typescript";
+import { cloneDeep } from 'lodash';
+import * as ts from 'typescript';
 
 const dummyIdentifiers = [
-  "ClassName",
-  "SDKClassName",
-  "SDKFunctionName",
-  "ClientName",
-  "functionClient"
+	'ClassName',
+	'SDKClassName',
+	'SDKFunctionName',
+	'ClientName',
+	'functionClient',
 ];
 
 const printer: ts.Printer = ts.createPrinter({
-  newLine: ts.NewLineKind.LineFeed,
-  removeComments: false
+	newLine: ts.NewLineKind.LineFeed,
+	removeComments: false,
 });
 
 function addMultiLineComment(node, comment: string) {
-  ts.addSyntheticLeadingComment(
-    node,
-    ts.SyntaxKind.MultiLineCommentTrivia,
-    comment,
-    true
-  );
+	ts.addSyntheticLeadingComment(
+		node,
+		ts.SyntaxKind.MultiLineCommentTrivia,
+		comment,
+		true
+	);
 }
 
 function runTransformation(sourceCode, transformMethod): Promise<string> {
-  return new Promise((resolve, reject) => {
-    try {
-      const result = ts.transform(sourceCode, [transformMethod]);
-      const transformedNodes = result.transformed[0];
-      const output = printer.printNode(
-        ts.EmitHint.SourceFile,
-        transformedNodes,
-        sourceCode
-      );
-      resolve(output);
-    } catch (error) {
-      reject(error);
-    }
-  });
+	return new Promise((resolve, reject) => {
+		try {
+			const result = ts.transform(sourceCode, [transformMethod]);
+			const transformedNodes = result.transformed[0];
+			const output = printer.printNode(
+				ts.EmitHint.SourceFile,
+				transformedNodes,
+				sourceCode
+			);
+			resolve(output);
+		} catch (error) {
+			reject(error);
+		}
+	});
 }
 
 function toSourceFile(sourceCode: string): ts.SourceFile {
-  return ts.createSourceFile(
-    "dummyClass.js",
-    sourceCode,
-    ts.ScriptTarget.Latest,
-    true
-  );
+	return ts.createSourceFile(
+		'dummyClass.js',
+		sourceCode,
+		ts.ScriptTarget.Latest,
+		true
+	);
 }
 
 export async function transform(
-  code: ts.SourceFile,
-  classData: any
+	code: ts.SourceFile,
+	classData: any
 ): Promise<string> {
-  const node: any = code.statements.find(stm => ts.isClassDeclaration(stm));
+	const node: any = code.statements.find(stm => ts.isClassDeclaration(stm));
 
-  if (!classData.functions) {
-    throw new Error("Input is invalid");
-  }
+	if (!classData.functions) {
+		throw new Error('Input is invalid');
+	}
 
-  if (!node || !node.members.some(member => ts.isMethodDeclaration(member))) {
-    throw new Error("Code is invalid");
-  }
+	if (!node || !node.members.some(member => ts.isMethodDeclaration(member))) {
+		throw new Error('Code is invalid');
+	}
 
-  code = cloneDeep(code);
+	code = cloneDeep(code);
 
-  // import related
-  classData.clients = Array.from(
-    new Set(classData.functions.map(method => method.client))
-  );
-  const importStatments: any = new Array(classData.clients.length);
-  importStatments.fill(Object.assign({}, code.statements[0]));
-  code.statements = importStatments.concat(code.statements.slice(1));
-  // import related
+	// import related
+	classData.clients = Array.from(
+		new Set(classData.functions.map(method => method.client))
+	);
+	const importStatments: any = new Array(classData.clients.length);
+	importStatments.fill(Object.assign({}, code.statements[0]));
+	code.statements = importStatments.concat(code.statements.slice(1));
+	// import related
 
-  const addFunctions = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isClassDeclaration(node)) {
-        let functions: any = [];
-        classData.functions.map(method => {
-          const clonedNode = Object.assign({}, node.members[1]);
-          clonedNode.name = ts.createIdentifier(method.functionName);
-          functions.push(clonedNode);
-        });
+	const addFunctions = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isClassDeclaration(node)) {
+				let functions: any = [];
+				classData.functions.map(method => {
+					const clonedNode = Object.assign({}, node.members[1]);
+					clonedNode.name = ts.createIdentifier(method.functionName);
+					functions.push(clonedNode);
+				});
 
-        const updatedClass = ts.updateClassDeclaration(
-          node,
-          node.decorators,
-          node.modifiers,
-          node.name,
-          node.typeParameters,
-          node.heritageClauses,
-          ts.createNodeArray([node.members[0]].concat(functions))
-        );
+				const updatedClass = ts.updateClassDeclaration(
+					node,
+					node.decorators,
+					node.modifiers,
+					node.name,
+					node.typeParameters,
+					node.heritageClauses,
+					ts.createNodeArray([node.members[0]].concat(functions))
+				);
 
-        return updatedClass;
-      }
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+				return updatedClass;
+			}
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  const addIdentifiers = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    let count = 0;
-    let clientCount = 0;
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isMethodDeclaration(node)) {
-        const parameters = classData.functions[count].params.map(param => {
-          const paramNode = ts.createParameter(
-            undefined,
-            undefined,
-            undefined,
-            param.name
-          );
+	const addIdentifiers = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		let count = 0;
+		let clientCount = 0;
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isMethodDeclaration(node)) {
+				const parameters = classData.functions[count].params.map(
+					param => {
+						const paramNode = ts.createParameter(
+							undefined,
+							undefined,
+							undefined,
+							param.name
+						);
 
-          if (param.optional) {
-            paramNode.initializer = ts.createIdentifier("undefined");
-          }
+						if (param.optional) {
+							paramNode.initializer = ts.createIdentifier(
+								'undefined'
+							);
+						}
 
-          return paramNode;
-        });
+						return paramNode;
+					}
+				);
 
-        node.parameters = parameters;
-      }
+				node.parameters = parameters;
+			}
 
-      if (ts.isStringLiteral(node) && node.text === "pkgName") {
-        return ts.createStringLiteral(
-          "@azure/" + classData.functions[0].pkgName
-        );
-      }
+			if (ts.isStringLiteral(node) && node.text === 'pkgName') {
+				return ts.createStringLiteral(
+					'@azure/' + classData.functions[0].pkgName
+				);
+			}
 
-      if (ts.isIdentifier(node) && dummyIdentifiers.includes(node.text)) {
-        let updatedIdentifier;
-        switch (node.text) {
-          case "ClassName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier("Azure_" + classData.serviceName)
-            );
-            break;
-          case "SDKClassName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(
-                classData.functions[count].fileName.split(".")[0]
-              )
-            );
-            break;
-          case "functionClient":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(classData.functions[count].client)
-            );
-            break;
-          case "ClientName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(classData.clients[clientCount])
-            );
-            clientCount++;
-            break;
-          case "SDKFunctionName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(classData.functions[count].SDKFunctionName)
-            );
-            count++;
-        }
-        return updatedIdentifier;
-      }
+			if (ts.isIdentifier(node) && dummyIdentifiers.includes(node.text)) {
+				let updatedIdentifier;
+				switch (node.text) {
+					case 'ClassName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								'Azure_' + classData.serviceName
+							)
+						);
+						break;
+					case 'SDKClassName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								classData.functions[count].fileName.split(
+									'.'
+								)[0]
+							)
+						);
+						break;
+					case 'functionClient':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								classData.functions[count].client
+							)
+						);
+						break;
+					case 'ClientName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(classData.clients[clientCount])
+						);
+						clientCount++;
+						break;
+					case 'SDKFunctionName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								classData.functions[count].SDKFunctionName
+							)
+						);
+						count++;
+				}
+				return updatedIdentifier;
+			}
 
-      if (ts.isCallExpression(node)) {
-        node.expression.forEachChild(childNode => {
-          if (
-            ts.isIdentifier(childNode) &&
-            childNode.text === "SDKFunctionName"
-          ) {
-            const args = classData.functions[count].params.map(param =>
-              ts.createIdentifier(param.name)
-            );
-            node.arguments = args;
-          }
-        });
-      }
+			if (ts.isCallExpression(node)) {
+				node.expression.forEachChild(childNode => {
+					if (
+						ts.isIdentifier(childNode) &&
+						childNode.text === 'SDKFunctionName'
+					) {
+						const args = classData.functions[count].params.map(
+							param => ts.createIdentifier(param.name)
+						);
+						node.arguments = args;
+					}
+				});
+			}
 
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  const addComments = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    let count = 0;
+	const addComments = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		let count = 0;
 
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isClassDeclaration(node)) {
-        addMultiLineComment(
-          node,
-          "This is an auto generated class, please do not change."
-        );
-        const comment = `*
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isClassDeclaration(node)) {
+				addMultiLineComment(
+					node,
+					'This is an auto generated class, please do not change.'
+				);
+				const comment = `*
  * Class to create a ${classData.serviceName} object
  * @category Azure
  `;
-        addMultiLineComment(node, comment);
-      }
+				addMultiLineComment(node, comment);
+			}
 
-      if (ts.isMethodDeclaration(node)) {
-        let parameters = classData.functions[count].params.map(param => {
-          let statment;
+			if (ts.isMethodDeclaration(node)) {
+				let parameters = classData.functions[count].params.map(
+					param => {
+						let statment;
 
-          if (param.optional) {
-            statment = `* @param {${param.type}} [${param.name}] - Optional parameter`;
-          } else {
-            statment = `* @param {${param.type}} ${param.name} - Mandatory parameter`;
-          }
-          return statment;
-        });
+						if (param.optional) {
+							statment = `* @param {${param.type}} [${param.name}] - Optional parameter`;
+						} else {
+							statment = `* @param {${param.type}} ${param.name} - Mandatory parameter`;
+						}
+						return statment;
+					}
+				);
 
-        let comment;
-        if (parameters.length > 0) {
-          let paramStatments: string = "";
-          parameters.map(param => {
-            paramStatments = paramStatments.concat(
-              paramStatments === "" ? `${param}` : `\n ${param}`
-            );
-          });
+				let comment;
+				if (parameters.length > 0) {
+					let paramStatments: string = '';
+					parameters.map(param => {
+						paramStatments = paramStatments.concat(
+							paramStatments === '' ? `${param}` : `\n ${param}`
+						);
+					});
 
-          comment = `*
+					comment = `*
  * Trigers the ${classData.functions[count].SDKFunctionName} function of ${
-            classData.functions[0].pkgName.split("-")[1]
-          }
+						classData.functions[0].pkgName.split('-')[1]
+					}
  ${paramStatments}
  * @returns {Promise<${classData.functions[count].SDKFunctionName}Response>}
  `;
-        } else {
-          comment = `*
+				} else {
+					comment = `*
  * Trigers the ${classData.functions[count].SDKFunctionName} function of ${
-            classData.functions[0].pkgName.split("-")[1]
-          }
+						classData.functions[0].pkgName.split('-')[1]
+					}
  * @returns {Promise<${classData.functions[count].SDKFunctionName}Response>}
  `;
-        }
+				}
 
-        addMultiLineComment(node, comment);
-        count++;
-      }
+				addMultiLineComment(node, comment);
+				count++;
+			}
 
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  const result_1 = await runTransformation(code, addFunctions);
-  const result_2 = await runTransformation(
-    toSourceFile(result_1),
-    addIdentifiers
-  );
-  const result_3 = await runTransformation(toSourceFile(result_2), addComments);
-  return result_3;
+	const result_1 = await runTransformation(code, addFunctions);
+	const result_2 = await runTransformation(
+		toSourceFile(result_1),
+		addIdentifiers
+	);
+	const result_3 = await runTransformation(
+		toSourceFile(result_2),
+		addComments
+	);
+	return result_3;
 }

--- a/generator/transformers/do/transformer.ts
+++ b/generator/transformers/do/transformer.ts
@@ -1,51 +1,51 @@
-import { cloneDeep } from "lodash";
-import * as ts from "typescript";
+import { cloneDeep } from 'lodash';
+import * as ts from 'typescript';
 
 const dummyIdentifiers = [
-  "ClassName",
-  "_sdkClassName",
-  "SDKClassName",
-  "SDKFunctionName"
+	'ClassName',
+	'_sdkClassName',
+	'SDKClassName',
+	'SDKFunctionName',
 ];
 
 const printer: ts.Printer = ts.createPrinter({
-  newLine: ts.NewLineKind.LineFeed,
-  removeComments: false
+	newLine: ts.NewLineKind.LineFeed,
+	removeComments: false,
 });
 
 function addMultiLineComment(node, comment: string) {
-  ts.addSyntheticLeadingComment(
-    node,
-    ts.SyntaxKind.MultiLineCommentTrivia,
-    comment,
-    true
-  );
+	ts.addSyntheticLeadingComment(
+		node,
+		ts.SyntaxKind.MultiLineCommentTrivia,
+		comment,
+		true
+	);
 }
 
 function runTransformation(sourceCode, transformMethod): Promise<string> {
-  return new Promise((resolve, reject) => {
-    try {
-      const result = ts.transform(sourceCode, [transformMethod]);
-      const transformedNodes = result.transformed[0];
-      const output = printer.printNode(
-        ts.EmitHint.SourceFile,
-        transformedNodes,
-        sourceCode
-      );
-      resolve(output);
-    } catch (error) {
-      reject(error);
-    }
-  });
+	return new Promise((resolve, reject) => {
+		try {
+			const result = ts.transform(sourceCode, [transformMethod]);
+			const transformedNodes = result.transformed[0];
+			const output = printer.printNode(
+				ts.EmitHint.SourceFile,
+				transformedNodes,
+				sourceCode
+			);
+			resolve(output);
+		} catch (error) {
+			reject(error);
+		}
+	});
 }
 
 function toSourceFile(sourceCode: string): ts.SourceFile {
-  return ts.createSourceFile(
-    "dummyClass.js",
-    sourceCode,
-    ts.ScriptTarget.Latest,
-    true
-  );
+	return ts.createSourceFile(
+		'dummyClass.js',
+		sourceCode,
+		ts.ScriptTarget.Latest,
+		true
+	);
 }
 
 /*
@@ -53,215 +53,228 @@ function toSourceFile(sourceCode: string): ts.SourceFile {
  */
 
 export async function transform(
-  code: ts.SourceFile,
-  classData: any
+	code: ts.SourceFile,
+	classData: any
 ): Promise<string> {
-  /*
-   * Transformation function for adding Functions
-   */
-  const addFunctions = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isClassDeclaration(node)) {
-        let functions: any = [];
-        classData.functions.map(method => {
-          const clonedNode = Object.assign({}, node.members[1]);
-          // console.log("Cloned Node..........\n");//sdadas
-          // console.log(clonedNode);//asdasdasdasd
-          clonedNode.name = ts.createIdentifier(method.functionName);
-          functions.push(clonedNode);
-        });
+	/*
+	 * Transformation function for adding Functions
+	 */
+	const addFunctions = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isClassDeclaration(node)) {
+				let functions: any = [];
+				classData.functions.map(method => {
+					const clonedNode = Object.assign({}, node.members[1]);
+					// console.log("Cloned Node..........\n");//sdadas
+					// console.log(clonedNode);//asdasdasdasd
+					clonedNode.name = ts.createIdentifier(method.functionName);
+					functions.push(clonedNode);
+				});
 
-        const updatedClass = ts.updateClassDeclaration(
-          node,
-          node.decorators,
-          node.modifiers,
-          node.name,
-          node.typeParameters,
-          node.heritageClauses,
-          ts.createNodeArray([node.members[0]].concat(functions))
-        );
+				const updatedClass = ts.updateClassDeclaration(
+					node,
+					node.decorators,
+					node.modifiers,
+					node.name,
+					node.typeParameters,
+					node.heritageClauses,
+					ts.createNodeArray([node.members[0]].concat(functions))
+				);
 
-        return updatedClass;
-      }
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+				return updatedClass;
+			}
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  /*
-   *  Transformation function for adding Identifiers/Parameters
-   */
-  const addIdentifiers = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    let count = 0;
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isMethodDeclaration(node)) {
-        const parameters = classData.functions[count].params.map(param => {
-          const paramNode = ts.createParameter(
-            undefined,
-            undefined,
-            undefined,
-            param.name
-          );
+	/*
+	 *  Transformation function for adding Identifiers/Parameters
+	 */
+	const addIdentifiers = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		let count = 0;
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isMethodDeclaration(node)) {
+				const parameters = classData.functions[count].params.map(
+					param => {
+						const paramNode = ts.createParameter(
+							undefined,
+							undefined,
+							undefined,
+							param.name
+						);
 
-          if (param.optional) {
-            paramNode.initializer = ts.createIdentifier("undefined");
-          }
+						if (param.optional) {
+							paramNode.initializer = ts.createIdentifier(
+								'undefined'
+							);
+						}
 
-          return paramNode;
-        });
+						return paramNode;
+					}
+				);
 
-        node.parameters = parameters;
-      }
+				node.parameters = parameters;
+			}
 
-      if (ts.isIdentifier(node) && dummyIdentifiers.includes(node.text)) {
-        let updatedIdentifier;
+			if (ts.isIdentifier(node) && dummyIdentifiers.includes(node.text)) {
+				let updatedIdentifier;
 
-        switch (node.text) {
-          case "ClassName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier("DO_" + classData.serviceName)
-            );
-            break;
-          case "_sdkClassName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(
-                "_" +
-                  classData.className.charAt(0).toLowerCase() +
-                  classData.className.substr(1)
-              )
-            );
-            break;
-          case "SDKClassName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(
-                classData.className.charAt(0).toLowerCase() +
-                  classData.className.substr(1)
-              )
-            );
-            break;
-          case "SDKFunctionName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(classData.functions[count].SDKFunctionName)
-            );
-            count++;
-        }
+				switch (node.text) {
+					case 'ClassName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier('DO_' + classData.serviceName)
+						);
+						break;
+					case '_sdkClassName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								'_' +
+									classData.className
+										.charAt(0)
+										.toLowerCase() +
+									classData.className.substr(1)
+							)
+						);
+						break;
+					case 'SDKClassName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								classData.className.charAt(0).toLowerCase() +
+									classData.className.substr(1)
+							)
+						);
+						break;
+					case 'SDKFunctionName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								classData.functions[count].SDKFunctionName
+							)
+						);
+						count++;
+				}
 
-        return updatedIdentifier;
-      }
+				return updatedIdentifier;
+			}
 
-      if (ts.isCallExpression(node)) {
-        node.expression.forEachChild(childNode => {
-          if (
-            ts.isIdentifier(childNode) &&
-            childNode.text === "SDKFunctionName"
-          ) {
-            const args = classData.functions[count].params.map(param =>
-              ts.createIdentifier(param.name)
-            );
-            node.arguments = args.concat(node.arguments);
-          }
-        });
-      }
+			if (ts.isCallExpression(node)) {
+				node.expression.forEachChild(childNode => {
+					if (
+						ts.isIdentifier(childNode) &&
+						childNode.text === 'SDKFunctionName'
+					) {
+						const args = classData.functions[count].params.map(
+							param => ts.createIdentifier(param.name)
+						);
+						node.arguments = args.concat(node.arguments);
+					}
+				});
+			}
 
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  /*
-   *Transformation function for adding comments
-   */
+	/*
+	 *Transformation function for adding comments
+	 */
 
-  const addComments = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    let count = 0;
+	const addComments = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		let count = 0;
 
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isClassDeclaration(node)) {
-        addMultiLineComment(
-          node,
-          "This is an auto generated class, please do not change."
-        );
-        const comment = `*
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isClassDeclaration(node)) {
+				addMultiLineComment(
+					node,
+					'This is an auto generated class, please do not change.'
+				);
+				const comment = `*
 * Class to create a ${classData.className} object
 * @category Digital Ocean       
 `;
-        addMultiLineComment(node, comment);
-      }
+				addMultiLineComment(node, comment);
+			}
 
-      if (ts.isMethodDeclaration(node)) {
-        let parameters = classData.functions[count].params.map(param => {
-          let statment;
+			if (ts.isMethodDeclaration(node)) {
+				let parameters = classData.functions[count].params.map(
+					param => {
+						let statment;
 
-          if (param.optional) {
-            if (param.type == "TypeReference")
-              statment = `* @param {${param.typeName}} ${param.name} - Data required for ${classData.functions[count].SDKFunctionName}`;
-            else
-              statment = `* @param {${param.type}} ${param.name} - Data required for ${classData.functions[count].SDKFunctionName}`;
-          } else {
-            if (param.type == "TypeReference")
-              statment = `* @param {${param.typeName}} ${param.name} - Data required for ${classData.functions[count].SDKFunctionName}`;
-            else
-              statment = `* @param {${param.type}} ${param.name} - Data required for ${classData.functions[count].SDKFunctionName}`;
-          }
-          return statment;
-        });
+						if (param.optional) {
+							if (param.type == 'TypeReference')
+								statment = `* @param {${param.typeName}} ${param.name} - Data required for ${classData.functions[count].SDKFunctionName}`;
+							else
+								statment = `* @param {${param.type}} ${param.name} - Data required for ${classData.functions[count].SDKFunctionName}`;
+						} else {
+							if (param.type == 'TypeReference')
+								statment = `* @param {${param.typeName}} ${param.name} - Data required for ${classData.functions[count].SDKFunctionName}`;
+							else
+								statment = `* @param {${param.type}} ${param.name} - Data required for ${classData.functions[count].SDKFunctionName}`;
+						}
+						return statment;
+					}
+				);
 
-        let comment;
-        if (parameters.length > 0) {
-          let paramStatments: string = "";
-          parameters.map(param => {
-            paramStatments = paramStatments.concat(
-              paramStatments === "" ? `${param}` : `\n${param}`
-            );
-          });
+				let comment;
+				if (parameters.length > 0) {
+					let paramStatments: string = '';
+					parameters.map(param => {
+						paramStatments = paramStatments.concat(
+							paramStatments === '' ? `${param}` : `\n${param}`
+						);
+					});
 
-          comment = `*
+					comment = `*
 * Trigers the ${classData.functions[count].SDKFunctionName} function of ${classData.className}
 ${paramStatments}
 * @returns {Promise<${classData.functions[count].SDKFunctionName}Response>}
 `;
-        } else {
-          comment = `*
+				} else {
+					comment = `*
 * Trigers the ${classData.functions[count].SDKFunctionName} function of ${classData.className}
 * @returns {Promise<${classData.functions[count].SDKFunctionName}Response>}
 `;
-        }
+				}
 
-        addMultiLineComment(node, comment);
-        count++;
-      }
+				addMultiLineComment(node, comment);
+				count++;
+			}
 
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  /*
-   * Code to get node and run tranformations
-   */
-  const node: any = code.statements.find(stm => ts.isClassDeclaration(stm));
+	/*
+	 * Code to get node and run tranformations
+	 */
+	const node: any = code.statements.find(stm => ts.isClassDeclaration(stm));
 
-  if (!classData.className || !classData.functions) {
-    throw new Error("Input is invalid");
-  }
+	if (!classData.className || !classData.functions) {
+		throw new Error('Input is invalid');
+	}
 
-  if (!node || !node.members.some(member => ts.isMethodDeclaration(member))) {
-    throw new Error("Code is invalid");
-  }
+	if (!node || !node.members.some(member => ts.isMethodDeclaration(member))) {
+		throw new Error('Code is invalid');
+	}
 
-  code = cloneDeep(code);
+	code = cloneDeep(code);
 
-  const result_1 = await runTransformation(code, addFunctions);
-  const result_2 = await runTransformation(
-    toSourceFile(result_1),
-    addIdentifiers
-  );
-  const result_3 = await runTransformation(toSourceFile(result_2), addComments);
-  return result_3;
+	const result_1 = await runTransformation(code, addFunctions);
+	const result_2 = await runTransformation(
+		toSourceFile(result_1),
+		addIdentifiers
+	);
+	const result_3 = await runTransformation(
+		toSourceFile(result_2),
+		addComments
+	);
+	return result_3;
 }

--- a/generator/transformers/googleCloud/classBasedTransformer.ts
+++ b/generator/transformers/googleCloud/classBasedTransformer.ts
@@ -1,310 +1,334 @@
-import { cloneDeep } from "lodash";
-import * as ts from "typescript";
+import { cloneDeep } from 'lodash';
+import * as ts from 'typescript';
 
 const dummyIdentifiers = [
-  "ClassName",
-  "SDKFunctionName",
-  "ClientName",
-  "_client",
-  "_clientObj",
-  "Client",
-  "_className"
+	'ClassName',
+	'SDKFunctionName',
+	'ClientName',
+	'_client',
+	'_clientObj',
+	'Client',
+	'_className',
 ];
 
 const printer: ts.Printer = ts.createPrinter({
-  newLine: ts.NewLineKind.LineFeed,
-  removeComments: false
+	newLine: ts.NewLineKind.LineFeed,
+	removeComments: false,
 });
 
 function addMultiLineComment(node, comment: string) {
-  ts.addSyntheticLeadingComment(
-    node,
-    ts.SyntaxKind.MultiLineCommentTrivia,
-    comment,
-    true
-  );
+	ts.addSyntheticLeadingComment(
+		node,
+		ts.SyntaxKind.MultiLineCommentTrivia,
+		comment,
+		true
+	);
 }
 
 function runTransformation(sourceCode, transformMethod): Promise<string> {
-  return new Promise((resolve, reject) => {
-    try {
-      const result = ts.transform(sourceCode, [transformMethod]);
-      const transformedNodes = result.transformed[0];
-      const output = printer.printNode(
-        ts.EmitHint.SourceFile,
-        transformedNodes,
-        sourceCode
-      );
-      resolve(output);
-    } catch (error) {
-      reject(error);
-    }
-  });
+	return new Promise((resolve, reject) => {
+		try {
+			const result = ts.transform(sourceCode, [transformMethod]);
+			const transformedNodes = result.transformed[0];
+			const output = printer.printNode(
+				ts.EmitHint.SourceFile,
+				transformedNodes,
+				sourceCode
+			);
+			resolve(output);
+		} catch (error) {
+			reject(error);
+		}
+	});
 }
 
 function toSourceFile(sourceCode: string): ts.SourceFile {
-  return ts.createSourceFile(
-    "dummyClass.js",
-    sourceCode,
-    ts.ScriptTarget.Latest,
-    true
-  );
+	return ts.createSourceFile(
+		'dummyClass.js',
+		sourceCode,
+		ts.ScriptTarget.Latest,
+		true
+	);
 }
 
 export async function classBasedTransform(
-  code: ts.SourceFile,
-  data: any
+	code: ts.SourceFile,
+	data: any
 ): Promise<string> {
-  const node: any = code.statements.find(stm => ts.isClassDeclaration(stm));
+	const node: any = code.statements.find(stm => ts.isClassDeclaration(stm));
 
-  if (!data.functions || !data.classData) {
-    throw new Error("Input is invalid");
-  }
+	if (!data.functions || !data.classData) {
+		throw new Error('Input is invalid');
+	}
 
-  if (!node || !node.members.some(member => ts.isMethodDeclaration(member))) {
-    throw new Error("Code is invalid");
-  }
+	if (!node || !node.members.some(member => ts.isMethodDeclaration(member))) {
+		throw new Error('Code is invalid');
+	}
 
-  code = cloneDeep(code);
+	code = cloneDeep(code);
 
-  const addFunctions = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isClassDeclaration(node)) {
-        let functions: any = [];
-        data.functions.map(method => {
-          let clonedNode;
-          if (method.returnTypeName === "Promise") {
-            if (
-              (method.classConstructorData.parameters[0].type =
-                "TypeReference" &&
-                !method.classConstructorData.parameters[0].optional)
-            ) {
-              clonedNode = Object.assign({}, node.members[3]);
-            } else {
-              clonedNode = Object.assign({}, node.members[1]);
-            }
-          } else {
-            clonedNode = Object.assign({}, node.members[2]);
-          }
-          clonedNode.name = ts.createIdentifier(method.functionName);
-          functions.push(clonedNode);
-        });
+	const addFunctions = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isClassDeclaration(node)) {
+				let functions: any = [];
+				data.functions.map(method => {
+					let clonedNode;
+					if (method.returnTypeName === 'Promise') {
+						if (
+							(method.classConstructorData.parameters[0].type =
+								'TypeReference' &&
+								!method.classConstructorData.parameters[0]
+									.optional)
+						) {
+							clonedNode = Object.assign({}, node.members[3]);
+						} else {
+							clonedNode = Object.assign({}, node.members[1]);
+						}
+					} else {
+						clonedNode = Object.assign({}, node.members[2]);
+					}
+					clonedNode.name = ts.createIdentifier(method.functionName);
+					functions.push(clonedNode);
+				});
 
-        const updatedClass = ts.updateClassDeclaration(
-          node,
-          node.decorators,
-          node.modifiers,
-          node.name,
-          node.typeParameters,
-          node.heritageClauses,
-          ts.createNodeArray([node.members[0]].concat(functions))
-        );
+				const updatedClass = ts.updateClassDeclaration(
+					node,
+					node.decorators,
+					node.modifiers,
+					node.name,
+					node.typeParameters,
+					node.heritageClauses,
+					ts.createNodeArray([node.members[0]].concat(functions))
+				);
 
-        return updatedClass;
-      }
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+				return updatedClass;
+			}
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  const addIdentifiers = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    let count = 0;
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isMethodDeclaration(node)) {
-        data.functions[count].allParams = [];
+	const addIdentifiers = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		let count = 0;
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isMethodDeclaration(node)) {
+				data.functions[count].allParams = [];
 
-        let params = [];
-        if (
-          (data.functions[count].classConstructorData.parameters[0].type =
-            "TypeReference" &&
-            !data.functions[count].classConstructorData.parameters[0].optional)
-        ) {
-          params.push(data.functions[count].classConstructorData.parameters[0]);
+				let params = [];
+				if (
+					(data.functions[
+						count
+					].classConstructorData.parameters[0].type =
+						'TypeReference' &&
+						!data.functions[count].classConstructorData
+							.parameters[0].optional)
+				) {
+					params.push(
+						data.functions[count].classConstructorData.parameters[0]
+					);
 
-          data.functions[count].allParams.push({
-            name: "identifier",
-            optional: true,
-            type: "string"
-          });
-        }
+					data.functions[count].allParams.push({
+						name: 'identifier',
+						optional: true,
+						type: 'string',
+					});
+				}
 
-        params = params.concat(data.functions[count].params);
-        data.functions[count].allParams = data.functions[
-          count
-        ].allParams.concat(params);
+				params = params.concat(data.functions[count].params);
+				data.functions[count].allParams = data.functions[
+					count
+				].allParams.concat(params);
 
-        const parameters: any = params.map(param => {
-          const paramNode = ts.createParameter(
-            undefined,
-            undefined,
-            undefined,
-            param.name
-          );
+				const parameters: any = params.map(param => {
+					const paramNode = ts.createParameter(
+						undefined,
+						undefined,
+						undefined,
+						param.name
+					);
 
-          if (param.optional) {
-            paramNode.initializer = ts.createIdentifier("undefined");
-          }
+					if (param.optional) {
+						paramNode.initializer = ts.createIdentifier(
+							'undefined'
+						);
+					}
 
-          return paramNode;
-        });
+					return paramNode;
+				});
 
-        node.parameters = parameters.concat(node.parameters);
-      }
+				node.parameters = parameters.concat(node.parameters);
+			}
 
-      if (ts.isStringLiteral(node) && node.text === "pkgName") {
-        return ts.createStringLiteral(
-          "@google-cloud/" + data.functions[0].pkgName
-        );
-      }
+			if (ts.isStringLiteral(node) && node.text === 'pkgName') {
+				return ts.createStringLiteral(
+					'@google-cloud/' + data.functions[0].pkgName
+				);
+			}
 
-      if (ts.isIdentifier(node) && dummyIdentifiers.includes(node.text)) {
-        let updatedIdentifier;
-        switch (node.text) {
-          case "ClassName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier("GCP_" + data.functions[0].pkgName)
-            );
-            break;
-          case "ClientName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(data.mainClass)
-            );
-            break;
-          case "SDKFunctionName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(data.functions[count].SDKFunctionName)
-            );
-            count++;
-            break;
-          case "_className":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(data.functions[count].client.toLowerCase())
-            );
-            break;
-          case "_client":
-            if (
-              (data.functions[count].classConstructorData.parameters[0].type =
-                "TypeReference" &&
-                !data.functions[count].classConstructorData.parameters[0]
-                  .optional)
-            ) {
-              updatedIdentifier = ts.updateIdentifier(
-                ts.createIdentifier(
-                  data.functions[count].classConstructorData.parameters[0].name
-                )
-              );
-            } else {
-              updatedIdentifier = ts.updateIdentifier(
-                ts.createIdentifier("_" + data.mainClass.toLowerCase())
-              );
-            }
-            break;
-          case "_clientObj":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier("_" + data.mainClass.toLowerCase())
-            );
-            break;
-          case "Client":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(data.mainClass)
-            );
-            break;
-        }
-        return updatedIdentifier;
-      }
+			if (ts.isIdentifier(node) && dummyIdentifiers.includes(node.text)) {
+				let updatedIdentifier;
+				switch (node.text) {
+					case 'ClassName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								'GCP_' + data.functions[0].pkgName
+							)
+						);
+						break;
+					case 'ClientName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(data.mainClass)
+						);
+						break;
+					case 'SDKFunctionName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								data.functions[count].SDKFunctionName
+							)
+						);
+						count++;
+						break;
+					case '_className':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								data.functions[count].client.toLowerCase()
+							)
+						);
+						break;
+					case '_client':
+						if (
+							(data.functions[
+								count
+							].classConstructorData.parameters[0].type =
+								'TypeReference' &&
+								!data.functions[count].classConstructorData
+									.parameters[0].optional)
+						) {
+							updatedIdentifier = ts.updateIdentifier(
+								ts.createIdentifier(
+									data.functions[count].classConstructorData
+										.parameters[0].name
+								)
+							);
+						} else {
+							updatedIdentifier = ts.updateIdentifier(
+								ts.createIdentifier(
+									'_' + data.mainClass.toLowerCase()
+								)
+							);
+						}
+						break;
+					case '_clientObj':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								'_' + data.mainClass.toLowerCase()
+							)
+						);
+						break;
+					case 'Client':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(data.mainClass)
+						);
+						break;
+				}
+				return updatedIdentifier;
+			}
 
-      if (ts.isCallExpression(node)) {
-        node.expression.forEachChild(childNode => {
-          if (
-            ts.isIdentifier(childNode) &&
-            childNode.text === "SDKFunctionName"
-          ) {
-            const args = data.functions[count].params.map(param =>
-              ts.createIdentifier(param.name)
-            );
-            node.arguments = args;
-          }
-        });
-      }
+			if (ts.isCallExpression(node)) {
+				node.expression.forEachChild(childNode => {
+					if (
+						ts.isIdentifier(childNode) &&
+						childNode.text === 'SDKFunctionName'
+					) {
+						const args = data.functions[count].params.map(param =>
+							ts.createIdentifier(param.name)
+						);
+						node.arguments = args;
+					}
+				});
+			}
 
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  const addComments = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    let count = 0;
+	const addComments = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		let count = 0;
 
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isClassDeclaration(node)) {
-        addMultiLineComment(
-          node,
-          "This is an auto generated class, please do not change."
-        );
-        const comment = `*
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isClassDeclaration(node)) {
+				addMultiLineComment(
+					node,
+					'This is an auto generated class, please do not change.'
+				);
+				const comment = `*
  * Class to create a ${data.functions[0].pkgName} object
  * @category Google Cloud
  `;
-        addMultiLineComment(node, comment);
-      }
+				addMultiLineComment(node, comment);
+			}
 
-      if (ts.isMethodDeclaration(node)) {
-        let parameters = data.functions[count].allParams.map(param => {
-          let statment;
+			if (ts.isMethodDeclaration(node)) {
+				let parameters = data.functions[count].allParams.map(param => {
+					let statment;
 
-          if (param.optional) {
-            statment = `* @param {${
-              param.typeRefName ? param.typeRefName : param.type
-            }} [${param.name}] - Optional parameter`;
-          } else {
-            statment = `* @param {${
-              param.typeRefName ? param.typeRefName : param.type
-            }} ${param.name} - Mandatory parameter`;
-          }
-          return statment;
-        });
+					if (param.optional) {
+						statment = `* @param {${
+							param.typeRefName ? param.typeRefName : param.type
+						}} [${param.name}] - Optional parameter`;
+					} else {
+						statment = `* @param {${
+							param.typeRefName ? param.typeRefName : param.type
+						}} ${param.name} - Mandatory parameter`;
+					}
+					return statment;
+				});
 
-        let comment;
-        if (parameters.length > 0) {
-          let paramStatments: string = "";
-          parameters.map(param => {
-            paramStatments = paramStatments.concat(
-              paramStatments === "" ? `${param}` : `\n ${param}`
-            );
-          });
+				let comment;
+				if (parameters.length > 0) {
+					let paramStatments: string = '';
+					parameters.map(param => {
+						paramStatments = paramStatments.concat(
+							paramStatments === '' ? `${param}` : `\n ${param}`
+						);
+					});
 
-          comment = `*
+					comment = `*
  * Trigers the ${data.functions[count].SDKFunctionName} function of ${data.functions[0].pkgName}
  ${paramStatments}
  * @returns {Promise<${data.functions[count].SDKFunctionName}Response>}
  `;
-        } else {
-          comment = `*
+				} else {
+					comment = `*
  * Trigers the ${data.functions[count].SDKFunctionName} function of ${data.functions[0].pkgName}
  * @returns {Promise<${data.functions[count].SDKFunctionName}Response>}
  `;
-        }
+				}
 
-        addMultiLineComment(node, comment);
-        count++;
-      }
+				addMultiLineComment(node, comment);
+				count++;
+			}
 
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  const result_1 = await runTransformation(code, addFunctions);
-  const result_2 = await runTransformation(
-    toSourceFile(result_1),
-    addIdentifiers
-  );
-  const result_3 = await runTransformation(toSourceFile(result_2), addComments);
-  return result_3;
+	const result_1 = await runTransformation(code, addFunctions);
+	const result_2 = await runTransformation(
+		toSourceFile(result_1),
+		addIdentifiers
+	);
+	const result_3 = await runTransformation(
+		toSourceFile(result_2),
+		addComments
+	);
+	return result_3;
 }

--- a/generator/transformers/googleCloud/clientBasedTransformer.ts
+++ b/generator/transformers/googleCloud/clientBasedTransformer.ts
@@ -1,292 +1,309 @@
-import { cloneDeep } from "lodash";
-import * as ts from "typescript";
+import { cloneDeep } from 'lodash';
+import * as ts from 'typescript';
 
 const dummyIdentifiers = [
-  "ClassName",
-  "SDKFunctionName",
-  "ClientName",
-  "_client",
-  "_clientObj",
-  "Client"
+	'ClassName',
+	'SDKFunctionName',
+	'ClientName',
+	'_client',
+	'_clientObj',
+	'Client',
 ];
 
 const printer: ts.Printer = ts.createPrinter({
-  newLine: ts.NewLineKind.LineFeed,
-  removeComments: false
+	newLine: ts.NewLineKind.LineFeed,
+	removeComments: false,
 });
 
 function addMultiLineComment(node, comment: string) {
-  ts.addSyntheticLeadingComment(
-    node,
-    ts.SyntaxKind.MultiLineCommentTrivia,
-    comment,
-    true
-  );
+	ts.addSyntheticLeadingComment(
+		node,
+		ts.SyntaxKind.MultiLineCommentTrivia,
+		comment,
+		true
+	);
 }
 
 function runTransformation(sourceCode, transformMethod): Promise<string> {
-  return new Promise((resolve, reject) => {
-    try {
-      const result = ts.transform(sourceCode, [transformMethod]);
-      const transformedNodes = result.transformed[0];
-      const output = printer.printNode(
-        ts.EmitHint.SourceFile,
-        transformedNodes,
-        sourceCode
-      );
-      resolve(output);
-    } catch (error) {
-      reject(error);
-    }
-  });
+	return new Promise((resolve, reject) => {
+		try {
+			const result = ts.transform(sourceCode, [transformMethod]);
+			const transformedNodes = result.transformed[0];
+			const output = printer.printNode(
+				ts.EmitHint.SourceFile,
+				transformedNodes,
+				sourceCode
+			);
+			resolve(output);
+		} catch (error) {
+			reject(error);
+		}
+	});
 }
 
 function toSourceFile(sourceCode: string): ts.SourceFile {
-  return ts.createSourceFile(
-    "dummyClass.js",
-    sourceCode,
-    ts.ScriptTarget.Latest,
-    true
-  );
+	return ts.createSourceFile(
+		'dummyClass.js',
+		sourceCode,
+		ts.ScriptTarget.Latest,
+		true
+	);
 }
 
 export async function clientBasedTransform(
-  code: ts.SourceFile,
-  classData: any
+	code: ts.SourceFile,
+	classData: any
 ): Promise<string> {
-  const node: any = code.statements.find(stm => ts.isClassDeclaration(stm));
+	const node: any = code.statements.find(stm => ts.isClassDeclaration(stm));
 
-  if (!classData.functions) {
-    throw new Error("Input is invalid");
-  }
+	if (!classData.functions) {
+		throw new Error('Input is invalid');
+	}
 
-  if (!node || !node.members.some(member => ts.isMethodDeclaration(member))) {
-    throw new Error("Code is invalid");
-  }
+	if (!node || !node.members.some(member => ts.isMethodDeclaration(member))) {
+		throw new Error('Code is invalid');
+	}
 
-  code = cloneDeep(code);
+	code = cloneDeep(code);
 
-  // import related
-  classData.clients = Array.from(
-    new Set(classData.functions.map(method => method.client))
-  );
-  const importStatments: any = new Array(classData.clients.length);
-  importStatments.fill(Object.assign({}, code.statements[0]));
-  code.statements = importStatments.concat(code.statements.slice(1));
+	// import related
+	classData.clients = Array.from(
+		new Set(classData.functions.map(method => method.client))
+	);
+	const importStatments: any = new Array(classData.clients.length);
+	importStatments.fill(Object.assign({}, code.statements[0]));
+	code.statements = importStatments.concat(code.statements.slice(1));
 
-  let classDeclarationNode: any = code.statements.find(node =>
-    ts.isClassDeclaration(node)
-  );
-  let constructorNode: any = classDeclarationNode.members.find(
-    node => ts.SyntaxKind[node.kind] === "Constructor"
-  );
-  const clientObjects: any = new Array(classData.clients.length);
-  clientObjects.fill(Object.assign({}, constructorNode.body.statements[0]));
-  constructorNode.body.statements = clientObjects;
-  // import related
+	let classDeclarationNode: any = code.statements.find(node =>
+		ts.isClassDeclaration(node)
+	);
+	let constructorNode: any = classDeclarationNode.members.find(
+		node => ts.SyntaxKind[node.kind] === 'Constructor'
+	);
+	const clientObjects: any = new Array(classData.clients.length);
+	clientObjects.fill(Object.assign({}, constructorNode.body.statements[0]));
+	constructorNode.body.statements = clientObjects;
+	// import related
 
-  const addFunctions = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isClassDeclaration(node)) {
-        let functions: any = [];
-        classData.functions.map(method => {
-          let clonedNode;
-          if (method.returnTypeName === "Promise") {
-            clonedNode = Object.assign({}, node.members[1]);
-          } else {
-            clonedNode = Object.assign({}, node.members[2]);
-          }
-          clonedNode.name = ts.createIdentifier(method.functionName);
-          functions.push(clonedNode);
-        });
+	const addFunctions = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isClassDeclaration(node)) {
+				let functions: any = [];
+				classData.functions.map(method => {
+					let clonedNode;
+					if (method.returnTypeName === 'Promise') {
+						clonedNode = Object.assign({}, node.members[1]);
+					} else {
+						clonedNode = Object.assign({}, node.members[2]);
+					}
+					clonedNode.name = ts.createIdentifier(method.functionName);
+					functions.push(clonedNode);
+				});
 
-        const updatedClass = ts.updateClassDeclaration(
-          node,
-          node.decorators,
-          node.modifiers,
-          node.name,
-          node.typeParameters,
-          node.heritageClauses,
-          ts.createNodeArray([node.members[0]].concat(functions))
-        );
+				const updatedClass = ts.updateClassDeclaration(
+					node,
+					node.decorators,
+					node.modifiers,
+					node.name,
+					node.typeParameters,
+					node.heritageClauses,
+					ts.createNodeArray([node.members[0]].concat(functions))
+				);
 
-        return updatedClass;
-      }
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+				return updatedClass;
+			}
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  const addIdentifiers = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    let count = 0;
-    let clientCount = 0;
-    let clientObjCount = 0;
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isMethodDeclaration(node)) {
-        const parameters = classData.functions[count].params.map(param => {
-          const paramNode = ts.createParameter(
-            undefined,
-            undefined,
-            undefined,
-            param.name
-          );
+	const addIdentifiers = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		let count = 0;
+		let clientCount = 0;
+		let clientObjCount = 0;
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isMethodDeclaration(node)) {
+				const parameters = classData.functions[count].params.map(
+					param => {
+						const paramNode = ts.createParameter(
+							undefined,
+							undefined,
+							undefined,
+							param.name
+						);
 
-          if (param.optional) {
-            paramNode.initializer = ts.createIdentifier("undefined");
-          }
+						if (param.optional) {
+							paramNode.initializer = ts.createIdentifier(
+								'undefined'
+							);
+						}
 
-          return paramNode;
-        });
+						return paramNode;
+					}
+				);
 
-        node.parameters = parameters;
-      }
+				node.parameters = parameters;
+			}
 
-      if (ts.isStringLiteral(node) && node.text === "pkgName") {
-        return ts.createStringLiteral(
-          "@google-cloud/" + classData.functions[0].pkgName
-        );
-      }
+			if (ts.isStringLiteral(node) && node.text === 'pkgName') {
+				return ts.createStringLiteral(
+					'@google-cloud/' + classData.functions[0].pkgName
+				);
+			}
 
-      if (ts.isIdentifier(node) && dummyIdentifiers.includes(node.text)) {
-        let updatedIdentifier;
-        switch (node.text) {
-          case "ClassName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier("GCP_" + classData.serviceName)
-            );
-            break;
-          case "ClientName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(classData.clients[clientCount])
-            );
-            clientCount++;
-            break;
-          case "SDKFunctionName":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(classData.functions[count].SDKFunctionName)
-            );
-            count++;
-            break;
-          case "_client":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(
-                "_" +
-                  classData.functions[count].client.toLowerCase().charAt(0) +
-                  classData.functions[count].client.substr(1)
-              )
-            );
-            break;
-          case "_clientObj":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(
-                "_" +
-                  classData.clients[clientObjCount].toLowerCase().charAt(0) +
-                  classData.clients[clientObjCount].substr(1)
-              )
-            );
-            break;
-          case "Client":
-            updatedIdentifier = ts.updateIdentifier(
-              ts.createIdentifier(classData.clients[clientObjCount])
-            );
-            clientObjCount++;
-            break;
-        }
-        return updatedIdentifier;
-      }
+			if (ts.isIdentifier(node) && dummyIdentifiers.includes(node.text)) {
+				let updatedIdentifier;
+				switch (node.text) {
+					case 'ClassName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier('GCP_' + classData.serviceName)
+						);
+						break;
+					case 'ClientName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(classData.clients[clientCount])
+						);
+						clientCount++;
+						break;
+					case 'SDKFunctionName':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								classData.functions[count].SDKFunctionName
+							)
+						);
+						count++;
+						break;
+					case '_client':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								'_' +
+									classData.functions[count].client
+										.toLowerCase()
+										.charAt(0) +
+									classData.functions[count].client.substr(1)
+							)
+						);
+						break;
+					case '_clientObj':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								'_' +
+									classData.clients[clientObjCount]
+										.toLowerCase()
+										.charAt(0) +
+									classData.clients[clientObjCount].substr(1)
+							)
+						);
+						break;
+					case 'Client':
+						updatedIdentifier = ts.updateIdentifier(
+							ts.createIdentifier(
+								classData.clients[clientObjCount]
+							)
+						);
+						clientObjCount++;
+						break;
+				}
+				return updatedIdentifier;
+			}
 
-      if (ts.isCallExpression(node)) {
-        node.expression.forEachChild(childNode => {
-          if (
-            ts.isIdentifier(childNode) &&
-            childNode.text === "SDKFunctionName"
-          ) {
-            const args = classData.functions[count].params.map(param =>
-              ts.createIdentifier(param.name)
-            );
-            node.arguments = args;
-          }
-        });
-      }
+			if (ts.isCallExpression(node)) {
+				node.expression.forEachChild(childNode => {
+					if (
+						ts.isIdentifier(childNode) &&
+						childNode.text === 'SDKFunctionName'
+					) {
+						const args = classData.functions[count].params.map(
+							param => ts.createIdentifier(param.name)
+						);
+						node.arguments = args;
+					}
+				});
+			}
 
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  const addComments = <T extends ts.Node>(
-    context: ts.TransformationContext
-  ) => (rootNode: T) => {
-    let count = 0;
+	const addComments = <T extends ts.Node>(
+		context: ts.TransformationContext
+	) => (rootNode: T) => {
+		let count = 0;
 
-    function visit(node: ts.Node): ts.Node {
-      if (ts.isClassDeclaration(node)) {
-        addMultiLineComment(
-          node,
-          "This is an auto generated class, please do not change."
-        );
-        const comment = `*
+		function visit(node: ts.Node): ts.Node {
+			if (ts.isClassDeclaration(node)) {
+				addMultiLineComment(
+					node,
+					'This is an auto generated class, please do not change.'
+				);
+				const comment = `*
  * Class to create a ${classData.serviceName} object
  * @category Google Cloud
  `;
-        addMultiLineComment(node, comment);
-      }
+				addMultiLineComment(node, comment);
+			}
 
-      if (ts.isMethodDeclaration(node)) {
-        let parameters = classData.functions[count].params.map(param => {
-          let statment;
+			if (ts.isMethodDeclaration(node)) {
+				let parameters = classData.functions[count].params.map(
+					param => {
+						let statment;
 
-          if (param.optional) {
-            statment = `* @param {${param.type}} [${param.name}] - Data required for ${classData.functions[count].SDKFunctionName}`;
-          } else {
-            statment = `* @param {${param.type}} ${param.name} - Data required for ${classData.functions[count].SDKFunctionName}`;
-          }
-          return statment;
-        });
+						if (param.optional) {
+							statment = `* @param {${param.type}} [${param.name}] - Data required for ${classData.functions[count].SDKFunctionName}`;
+						} else {
+							statment = `* @param {${param.type}} ${param.name} - Data required for ${classData.functions[count].SDKFunctionName}`;
+						}
+						return statment;
+					}
+				);
 
-        let comment;
-        if (parameters.length > 0) {
-          let paramStatments: string = "";
-          parameters.map(param => {
-            paramStatments = paramStatments.concat(
-              paramStatments === "" ? `${param}` : `\n ${param}`
-            );
-          });
+				let comment;
+				if (parameters.length > 0) {
+					let paramStatments: string = '';
+					parameters.map(param => {
+						paramStatments = paramStatments.concat(
+							paramStatments === '' ? `${param}` : `\n ${param}`
+						);
+					});
 
-          comment = `*
+					comment = `*
  * Trigers the ${classData.functions[count].SDKFunctionName} function of ${
-            classData.functions[0].pkgName.split("-")[1]
-          }
+						classData.functions[0].pkgName.split('-')[1]
+					}
  ${paramStatments}
  * @returns {Promise<${classData.functions[count].SDKFunctionName}Response>}
  `;
-        } else {
-          comment = `*
+				} else {
+					comment = `*
  * Trigers the ${classData.functions[count].SDKFunctionName} function of ${
-            classData.functions[0].pkgName.split("-")[1]
-          }
+						classData.functions[0].pkgName.split('-')[1]
+					}
  * @returns {Promise<${classData.functions[count].SDKFunctionName}Response>}
  `;
-        }
+				}
 
-        addMultiLineComment(node, comment);
-        count++;
-      }
+				addMultiLineComment(node, comment);
+				count++;
+			}
 
-      return ts.visitEachChild(node, visit, context);
-    }
-    return ts.visitNode(rootNode, visit);
-  };
+			return ts.visitEachChild(node, visit, context);
+		}
+		return ts.visitNode(rootNode, visit);
+	};
 
-  const result_1 = await runTransformation(code, addFunctions);
-  const result_2 = await runTransformation(
-    toSourceFile(result_1),
-    addIdentifiers
-  );
-  const result_3 = await runTransformation(toSourceFile(result_2), addComments);
-  return result_3;
+	const result_1 = await runTransformation(code, addFunctions);
+	const result_2 = await runTransformation(
+		toSourceFile(result_1),
+		addIdentifiers
+	);
+	const result_3 = await runTransformation(
+		toSourceFile(result_2),
+		addComments
+	);
+	return result_3;
 }

--- a/generator/tsconfig.json
+++ b/generator/tsconfig.json
@@ -1,7 +1,7 @@
 {
-  "compilerOptions": {
-    "module": "commonjs",
-    "sourceMap": true,
-    "target": "es2018"
-  }
+	"compilerOptions": {
+		"module": "commonjs",
+		"sourceMap": true,
+		"target": "es2018"
+	}
 }

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,21 +1,21 @@
 {
-  "source": {
-    "include": ["generator/generatedClasses/"],
-    "includePattern": ".js$",
-    "excludePattern": "(node_modules/|docs)"
-  },
-  "plugins": ["plugins/markdown", "node_modules/better-docs/category"],
-  "templates": {
-    "cleverLinks": true,
-    "monospaceLinks": true
-  },
-  "opts": {
-    "template": "node_modules/better-docs",
-    "recurse": true,
-    "destination": "./docs/",
-    "readme": "README.md"
-  },
-  "tags": {
-    "allowUnknownTags": ["category"]
-  }
+	"source": {
+		"include": ["generator/generatedClasses/"],
+		"includePattern": ".js$",
+		"excludePattern": "(node_modules/|docs)"
+	},
+	"plugins": ["plugins/markdown", "node_modules/better-docs/category"],
+	"templates": {
+		"cleverLinks": true,
+		"monospaceLinks": true
+	},
+	"opts": {
+		"template": "node_modules/better-docs",
+		"recurse": true,
+		"destination": "./docs/",
+		"readme": "README.md"
+	},
+	"tags": {
+		"allowUnknownTags": ["category"]
+	}
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
-  "packages": ["packages/*"],
-  "version": "independent",
-  "npmClient": "yarn",
-  "useWorkspaces": true
+	"packages": ["packages/*"],
+	"version": "independent",
+	"npmClient": "yarn",
+	"useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,62 +1,62 @@
 {
-  "name": "nodecloud",
-  "private": "true",
-  "workspaces": [
-    "packages/*",
-    "generator"
-  ],
-  "description": "⚡️ The Node.js API for open cloud",
-  "scripts": {
-    "test": "lerna run test",
-    "lint": "lerna run lint",
-    "prettier": "lerna run prettier",
-    "format": "prettier --write",
-    "doc": "jsdoc -c jsdoc.json",
-    "generator": " cd generator && tsc main.ts && node main.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/cloudlibz/nodecloud.git"
-  },
-  "keywords": [
-    "nodecloud",
-    "nodejs",
-    "node",
-    "node-cloud",
-    "node-aws",
-    "node-azure"
-  ],
-  "author": "scorelab",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/cloudlibz/nodecloud/issues"
-  },
-  "homepage": "https://github.com/cloudlibz/nodecloud#readme",
-  "devDependencies": {
-    "@types/chai": "^4.2.12",
-    "@types/lodash": "^4.14.158",
-    "@types/mocha": "^8.0.0",
-    "@types/node": "^14.0.6",
-    "@typescript-eslint/eslint-plugin": "^5.19.0",
-    "@typescript-eslint/parser": "^5.19.0",
-    "better-docs": "^2.3.0",
-    "chai": "^4.2.0",
-    "cross-env": "^7.0.2",
-    "eslint": "^8.13.0",
-    "eslint-plugin-simple-import-sort": "^7.0.0",
-    "husky": "^4.3.0",
-    "jsdoc": "^3.6.5",
-    "lerna": "^3.22.1",
-    "mocha": "^8.0.1",
-    "nock": "^9.6.1",
-    "prettier": "^1.15.3",
-    "pretty-quick": "^1.8.0",
-    "ts-node": "^8.10.2"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lerna run test && lerna run prettier && lerna run lint",
-      "pre-push": "lerna run test"
-    }
-  }
+	"name": "nodecloud",
+	"private": "true",
+	"workspaces": [
+		"packages/*",
+		"generator"
+	],
+	"description": "⚡️ The Node.js API for open cloud",
+	"scripts": {
+		"test": "lerna run test",
+		"lint": "lerna run lint",
+		"prettier": "lerna run prettier",
+		"format": "prettier --write {,*/**/}*.{ts,json}",
+		"doc": "jsdoc -c jsdoc.json",
+		"generator": " cd generator && tsc main.ts && node main.js"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/cloudlibz/nodecloud.git"
+	},
+	"keywords": [
+		"nodecloud",
+		"nodejs",
+		"node",
+		"node-cloud",
+		"node-aws",
+		"node-azure"
+	],
+	"author": "scorelab",
+	"license": "Apache-2.0",
+	"bugs": {
+		"url": "https://github.com/cloudlibz/nodecloud/issues"
+	},
+	"homepage": "https://github.com/cloudlibz/nodecloud#readme",
+	"devDependencies": {
+		"@types/chai": "^4.2.12",
+		"@types/lodash": "^4.14.158",
+		"@types/mocha": "^8.0.0",
+		"@types/node": "^14.0.6",
+		"@typescript-eslint/eslint-plugin": "^5.19.0",
+		"@typescript-eslint/parser": "^5.19.0",
+		"better-docs": "^2.3.0",
+		"chai": "^4.2.0",
+		"cross-env": "^7.0.2",
+		"eslint": "^8.13.0",
+		"eslint-plugin-simple-import-sort": "^7.0.0",
+		"husky": "^4.3.0",
+		"jsdoc": "^3.6.5",
+		"lerna": "^3.22.1",
+		"mocha": "^8.0.1",
+		"nock": "^9.6.1",
+		"prettier": "^1.15.3",
+		"pretty-quick": "^1.8.0",
+		"ts-node": "^8.10.2"
+	},
+	"husky": {
+		"hooks": {
+			"pre-commit": "lerna run test && lerna run prettier && lerna run lint",
+			"pre-push": "lerna run test"
+		}
+	}
 }

--- a/packages/aws-plugin/package.json
+++ b/packages/aws-plugin/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "@nodecloud/aws-plugin",
-  "version": "2.0.0",
-  "description": "NodeCloud AWS plugin",
-  "main": "index.js",
-  "scripts": {
-    "prettier": "yarn pretty-quick"
-  },
-  "keywords": [
-    "nodecloud",
-    "nodecloud-aws"
-  ],
-  "author": "Scorelab",
-  "license": "Apache-2.0",
-  "dependencies": {
-    "aws-sdk": "^2.686.0"
-  }
+	"name": "@nodecloud/aws-plugin",
+	"version": "2.0.0",
+	"description": "NodeCloud AWS plugin",
+	"main": "index.js",
+	"scripts": {
+		"prettier": "yarn pretty-quick"
+	},
+	"keywords": [
+		"nodecloud",
+		"nodecloud-aws"
+	],
+	"author": "Scorelab",
+	"license": "Apache-2.0",
+	"dependencies": {
+		"aws-sdk": "^2.686.0"
+	}
 }

--- a/packages/azure-plugin/package.json
+++ b/packages/azure-plugin/package.json
@@ -1,29 +1,29 @@
 {
-  "name": "@nodecloud/azure-plugin",
-  "version": "2.0.0",
-  "description": "NodeCloud Azure plugin",
-  "main": "index.js",
-  "scripts": {
-    "prettier": "yarn pretty-quick"
-  },
-  "keywords": [
-    "nodecloud",
-    "nodecloud-azure"
-  ],
-  "author": "Scorelab",
-  "license": "Apache-2.0",
-  "dependencies": {
-    "@azure/arm-appservice": "^6.0.0",
-    "@azure/arm-compute": "^14.0.0",
-    "@azure/arm-containerservice": "^11.0.0",
-    "@azure/arm-cosmosdb": "^9.1.0",
-    "@azure/arm-dns": "^4.0.0",
-    "@azure/arm-keyvault": "^1.2.1",
-    "@azure/arm-monitor": "^6.0.0",
-    "@azure/arm-network": "^22.0.0",
-    "@azure/arm-sql": "^7.0.2",
-    "@azure/arm-storage": "^15.1.0",
-    "@azure/ms-rest-js": "^2.0.7",
-    "@azure/ms-rest-nodeauth": "^3.0.5"
-  }
+	"name": "@nodecloud/azure-plugin",
+	"version": "2.0.0",
+	"description": "NodeCloud Azure plugin",
+	"main": "index.js",
+	"scripts": {
+		"prettier": "yarn pretty-quick"
+	},
+	"keywords": [
+		"nodecloud",
+		"nodecloud-azure"
+	],
+	"author": "Scorelab",
+	"license": "Apache-2.0",
+	"dependencies": {
+		"@azure/arm-appservice": "^6.0.0",
+		"@azure/arm-compute": "^14.0.0",
+		"@azure/arm-containerservice": "^11.0.0",
+		"@azure/arm-cosmosdb": "^9.1.0",
+		"@azure/arm-dns": "^4.0.0",
+		"@azure/arm-keyvault": "^1.2.1",
+		"@azure/arm-monitor": "^6.0.0",
+		"@azure/arm-network": "^22.0.0",
+		"@azure/arm-sql": "^7.0.2",
+		"@azure/arm-storage": "^15.1.0",
+		"@azure/ms-rest-js": "^2.0.7",
+		"@azure/ms-rest-nodeauth": "^3.0.5"
+	}
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "@nodecloud/common",
-  "version": "2.0.0",
-  "description": "NodeCloud core",
-  "main": "index.js",
-  "scripts": {
-    "test": "mocha \"./**/*.test.js\"",
-    "prettier": "yarn pretty-quick"
-  },
-  "keywords": [
-    "nodecloud"
-  ],
-  "author": "Scorelab",
-  "license": "Apache-2.0",
-  "dependencies": {
-    "config": "^1.26.1",
-    "key-mirror": "^1.0.1"
-  }
+	"name": "@nodecloud/common",
+	"version": "2.0.0",
+	"description": "NodeCloud core",
+	"main": "index.js",
+	"scripts": {
+		"test": "mocha \"./**/*.test.js\"",
+		"prettier": "yarn pretty-quick"
+	},
+	"keywords": [
+		"nodecloud"
+	],
+	"author": "Scorelab",
+	"license": "Apache-2.0",
+	"dependencies": {
+		"config": "^1.26.1",
+		"key-mirror": "^1.0.1"
+	}
 }

--- a/packages/do-plugin/package.json
+++ b/packages/do-plugin/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "@nodecloud/do-plugin",
-  "version": "2.0.0",
-  "description": "NodeCloud Digital Ocean plugin",
-  "main": "index.js",
-  "scripts": {
-    "prettier": "yarn pretty-quick"
-  },
-  "keywords": [
-    "nodecloud",
-    "nodecloud-Digital-Ocean"
-  ],
-  "author": "Scorelab",
-  "license": "Apache-2.0",
-  "dependencies": {
-    "do-wrapper": "^4.5.1"
-  }
+	"name": "@nodecloud/do-plugin",
+	"version": "2.0.0",
+	"description": "NodeCloud Digital Ocean plugin",
+	"main": "index.js",
+	"scripts": {
+		"prettier": "yarn pretty-quick"
+	},
+	"keywords": [
+		"nodecloud",
+		"nodecloud-Digital-Ocean"
+	],
+	"author": "Scorelab",
+	"license": "Apache-2.0",
+	"dependencies": {
+		"do-wrapper": "^4.5.1"
+	}
 }

--- a/packages/gcp-plugin/package.json
+++ b/packages/gcp-plugin/package.json
@@ -1,28 +1,28 @@
 {
-  "name": "@nodecloud/gcp-plugin",
-  "version": "2.0.0",
-  "description": "NodeCloud GCP plugin",
-  "main": "index.js",
-  "scripts": {
-    "prettier": "yarn pretty-quick"
-  },
-  "keywords": [
-    "nodecloud",
-    "nodecloud-gcp"
-  ],
-  "author": "Scorelab",
-  "license": "Apache-2.0",
-  "dependencies": {
-    "@google-cloud/automl": "^2.2.0",
-    "@google-cloud/compute": "^2.0.1",
-    "@google-cloud/container": "^2.1.1",
-    "@google-cloud/dns": "^2.0.1",
-    "@google-cloud/firestore": "^4.2.0",
-    "@google-cloud/kms": "^2.1.2",
-    "@google-cloud/monitoring": "^2.1.1",
-    "@google-cloud/pubsub": "^2.5.0",
-    "@google-cloud/spanner": "^5.2.1",
-    "@google-cloud/storage": "^5.1.1",
-    "@google-cloud/translate": "^6.0.2"
-  }
+	"name": "@nodecloud/gcp-plugin",
+	"version": "2.0.0",
+	"description": "NodeCloud GCP plugin",
+	"main": "index.js",
+	"scripts": {
+		"prettier": "yarn pretty-quick"
+	},
+	"keywords": [
+		"nodecloud",
+		"nodecloud-gcp"
+	],
+	"author": "Scorelab",
+	"license": "Apache-2.0",
+	"dependencies": {
+		"@google-cloud/automl": "^2.2.0",
+		"@google-cloud/compute": "^2.0.1",
+		"@google-cloud/container": "^2.1.1",
+		"@google-cloud/dns": "^2.0.1",
+		"@google-cloud/firestore": "^4.2.0",
+		"@google-cloud/kms": "^2.1.2",
+		"@google-cloud/monitoring": "^2.1.1",
+		"@google-cloud/pubsub": "^2.5.0",
+		"@google-cloud/spanner": "^5.2.1",
+		"@google-cloud/storage": "^5.1.1",
+		"@google-cloud/translate": "^6.0.2"
+	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,112 @@
 # yarn lockfile v1
 
 
+"@alicloud/credentials@^2":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@alicloud/credentials/-/credentials-2.2.3.tgz#6c479082e3f627311e2537c0552e3e87a8ecd671"
+  integrity sha512-h98BZimKCQ5xKiFCdWa2OMYaenEP6g5Fndm/l0zp8iuYWOShnvEwBPFmHyHmwpb60KwEJp0LILl1WiBTS+5a1w==
+  dependencies:
+    "@alicloud/tea-typescript" "^1.5.3"
+    httpx "^2.2.0"
+    ini "^1.3.5"
+    kitx "^2.0.0"
+
+"@alicloud/dds20151201@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@alicloud/dds20151201/-/dds20151201-1.0.3.tgz#08cd76c76448d7734c136be4ba816663bba5d645"
+  integrity sha512-Cu33AvSp1UF2z87uHCSS0XMTbf1ZadLSUAPcZXhzaEfKzzBmB07DvFg5if4p6Ut54aIVwAhFMu5X1dbNqowF7w==
+  dependencies:
+    "@alicloud/endpoint-util" "^0.0.1"
+    "@alicloud/openapi-client" "^0.3.5"
+    "@alicloud/tea-typescript" "^1.7.1"
+    "@alicloud/tea-util" "^1.4.0"
+
+"@alicloud/endpoint-util@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@alicloud/endpoint-util/-/endpoint-util-0.0.1.tgz#b237f5e04e373abb54c42119377b30bd6afb1a7c"
+  integrity sha512-+pH7/KEXup84cHzIL6UJAaPqETvln4yXlD9JzlrqioyCSaWxbug5FUobsiI6fuUOpw5WwoB3fWAtGbFnJ1K3Yg==
+  dependencies:
+    "@alicloud/tea-typescript" "^1.5.1"
+    kitx "^2.0.0"
+
+"@alicloud/openapi-client@^0.3.0", "@alicloud/openapi-client@^0.3.4", "@alicloud/openapi-client@^0.3.5":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@alicloud/openapi-client/-/openapi-client-0.3.8.tgz#61ef813722126cbcbb2938f44672d3c4bcc93915"
+  integrity sha512-QuvK6MJtQejSOfUnsEUtdM5AYA8Ww9kV79VO1st5sFPYQWV4R8NXm2yr40Jq4UQmKN2ydlRfbys3ACJDocVfqQ==
+  dependencies:
+    "@alicloud/credentials" "^2"
+    "@alicloud/openapi-util" "^0.2.4"
+    "@alicloud/tea-typescript" "^1.7.1"
+    "@alicloud/tea-util" "^1.4.0"
+
+"@alicloud/openapi-util@^0.2.4":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@alicloud/openapi-util/-/openapi-util-0.2.9.tgz#2379cd81f993dcab32066a2b892ddcbdd266d51c"
+  integrity sha512-GUEYtX3lDv+WaZoDFCb0h9aZ8+IlajnSAxSHjiITbNtjCpZbA/vfd7Z/ST9YaPoT34nGqDNKiQTjqpLhaKtYBw==
+  dependencies:
+    "@alicloud/tea-typescript" "^1.7.1"
+    "@alicloud/tea-util" "^1.3.0"
+    kitx "^2.1.0"
+    sm3 "^1.0.3"
+
+"@alicloud/rds20140815@2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@alicloud/rds20140815/-/rds20140815-2.0.7.tgz#49b22607e28d4d5159d29bf0c97fe49092df9ee7"
+  integrity sha512-QkXHSRJA1hdN1N/FDM6iAWC2Td242qsK1flctAPxF4Tg5YR0xbZfbc72kNmokutDM+vwiSguNmZqi7Ku8wdAeg==
+  dependencies:
+    "@alicloud/endpoint-util" "^0.0.1"
+    "@alicloud/openapi-client" "^0.3.4"
+    "@alicloud/openapi-util" "^0.2.4"
+    "@alicloud/rpc-client" "^1.3.1"
+    "@alicloud/tea-typescript" "^1.7.1"
+    "@alicloud/tea-util" "^1.4.0"
+
+"@alicloud/rpc-client@^1.3.1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@alicloud/rpc-client/-/rpc-client-1.3.2.tgz#6684f008fd01b1848da810368cfbff163ad92779"
+  integrity sha512-PjgkPXtgDyb0m+BJMaEU/2rOvjUVBqhemqrMhNW0vYKYGlyfdEOVfrHVieqkLe8lxvFGy6gD1PpvAjeEMUXfsA==
+  dependencies:
+    "@alicloud/credentials" "^2"
+    "@alicloud/rpc-util" "^0.1.0"
+    "@alicloud/tea-typescript" "^1.6.0"
+    "@alicloud/tea-util" "^1.4.0"
+
+"@alicloud/rpc-util@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@alicloud/rpc-util/-/rpc-util-0.1.0.tgz#f6f431cf1906f1090a27d0b37d2696be2758daf9"
+  integrity sha512-0J+OcSycsfJvX1SpqaGqVHE7lbCFsk2PwdkZUOrWfbqMYcQjCe/Kp/DfwqcTMkYhWmiV48Esfog8XNLEB34zUg==
+  dependencies:
+    "@alicloud/tea-typescript" "^1"
+    "@types/xml2js" "^0.4.5"
+    kitx "^2.0.0"
+    xml2js "^0.4.22"
+
+"@alicloud/slb20140515@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@alicloud/slb20140515/-/slb20140515-2.0.2.tgz#ba872dba2c19e5db614212d658358a1cd05deb56"
+  integrity sha512-hUvuKHxWfyHeJ4ElLS4zVm4bUHssj7wzGqcrbMx5ZmgrpoHWxLTP6jXJeXHQKIF8INahRsNyPcMrKk/9mE0OCA==
+  dependencies:
+    "@alicloud/endpoint-util" "^0.0.1"
+    "@alicloud/openapi-client" "^0.3.0"
+    "@alicloud/tea-typescript" latest
+    "@alicloud/tea-util" "^1.4.0"
+
+"@alicloud/tea-typescript@^1", "@alicloud/tea-typescript@^1.5.1", "@alicloud/tea-typescript@^1.5.3", "@alicloud/tea-typescript@^1.6.0", "@alicloud/tea-typescript@^1.7.1", "@alicloud/tea-typescript@latest":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@alicloud/tea-typescript/-/tea-typescript-1.7.2.tgz#1f9baf1093ff9f865f2b6091c2ba166aafd106cc"
+  integrity sha512-vDOU6qUp9ZAGlHSLC7lqVLgxUbmkcDXTEXyiIipvPWcq7dqwDDO6SeLlU7nBYI+yYWpbfOazEGkMTlHMhvA5Tw==
+  dependencies:
+    "@types/node" "^12.0.2"
+    httpx "^2.2.6"
+
+"@alicloud/tea-util@^1.3.0", "@alicloud/tea-util@^1.4.0":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@alicloud/tea-util/-/tea-util-1.4.3.tgz#e6d70fb3a9be0ca5b83da7b2fdbfb96197c5f2e6"
+  integrity sha512-8bYzfn+hmzp8L1tkfOX7XNqOOc57i23EAVe09SvM/DasySTtBFdONkDV+EtHzROohBI1zpbE61EFD8jGThg1OA==
+  dependencies:
+    "@alicloud/tea-typescript" "^1.5.1"
+    kitx "^2.0.0"
+
 "@azure/arm-appservice@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@azure/arm-appservice/-/arm-appservice-6.0.0.tgz#208c27b79bdd8a296249a4ac2714a2246af3df88"
@@ -1809,6 +1915,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.14.tgz#24a0b5959f16ac141aeb0c5b3cd7a15b7c64cbce"
   integrity sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==
 
+"@types/node@^12.0.2":
+  version "12.20.55"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
+  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+
 "@types/node@^12.12.47":
   version "12.12.54"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.54.tgz#a4b58d8df3a4677b6c08bfbc94b7ad7a7a5f82d1"
@@ -1818,6 +1929,11 @@
   version "13.13.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.12.tgz#9c72e865380a7dc99999ea0ef20fc9635b503d20"
   integrity sha512-zWz/8NEPxoXNT9YyF2osqyA9WjssZukYpgI4UYZpOjcyqwIUqWGkcCionaEb9Ki+FULyPyvNFpg/329Kd2/pbw==
+
+"@types/node@^14":
+  version "14.18.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.21.tgz#0155ee46f6be28b2ff0342ca1a9b9fd4468bef41"
+  integrity sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q==
 
 "@types/node@^8.0.47":
   version "8.10.61"
@@ -1865,6 +1981,13 @@
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@types/tunnel/-/tunnel-0.0.1.tgz#0d72774768b73df26f25df9184273a42da72b19c"
   integrity sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==
+  dependencies:
+    "@types/node" "*"
+
+"@types/xml2js@^0.4.5":
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/@types/xml2js/-/xml2js-0.4.11.tgz#bf46a84ecc12c41159a7bd9cf51ae84129af0e79"
+  integrity sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==
   dependencies:
     "@types/node" "*"
 
@@ -1989,6 +2112,11 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
+acorn-walk@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
@@ -2019,6 +2147,11 @@ adal-node@^0.1.28:
     xmldom ">= 0.1.x"
     xpath.js "~1.1.0"
 
+address@>=0.0.1, address@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/address/-/address-1.2.0.tgz#d352a62c92fee90f89a693eccd2a8b2139ab02d9"
+  integrity sha512-tNEZYz5G/zYunxFm7sfhAxkXEuLj3K6BKwv6ZURlsF6yiUQ65z0Q2wZW9L5cPUl9ocofGvXOdFYbFHp0+6MOig==
+
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
@@ -2030,6 +2163,13 @@ agent-base@6:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.1.tgz#808007e4e5867decb0ab6ab2f928fbdb5a596db4"
   integrity sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==
+  dependencies:
+    debug "4"
+
+agent-base@^6.0.0, agent-base@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
 
@@ -2067,6 +2207,36 @@ ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ali-oss@^6.17.1:
+  version "6.17.1"
+  resolved "https://registry.yarnpkg.com/ali-oss/-/ali-oss-6.17.1.tgz#3e88738ec01111a26a2b967cf857d97050886156"
+  integrity sha512-v2oT3UhSJTH/LrsscVvi7iEGrnundydNaFzpYAKatqOl4JNcBV4UiwtlJU+ZHLys040JH2k+CutznA0GoE+P2w==
+  dependencies:
+    address "^1.0.0"
+    agentkeepalive "^3.4.1"
+    bowser "^1.6.0"
+    copy-to "^2.0.1"
+    dateformat "^2.0.0"
+    debug "^2.2.0"
+    destroy "^1.0.4"
+    end-or-error "^1.0.1"
+    get-ready "^1.0.0"
+    humanize-ms "^1.2.0"
+    is-type-of "^1.0.0"
+    js-base64 "^2.5.2"
+    jstoxml "^2.0.0"
+    merge-descriptors "^1.0.1"
+    mime "^2.4.5"
+    mz-modules "^2.1.0"
+    platform "^1.3.1"
+    pump "^3.0.0"
+    sdk-base "^2.0.1"
+    stream-http "2.8.2"
+    stream-wormhole "^1.0.4"
+    urllib "^2.33.1"
+    utility "^1.8.0"
+    xml2js "^0.4.16"
+
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -2075,6 +2245,17 @@ align-text@^0.1.1, align-text@^0.1.3:
     kind-of "^3.0.2"
     longest "^1.0.1"
     repeat-string "^1.5.2"
+
+aliyun-v2-typescript-sdk@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/aliyun-v2-typescript-sdk/-/aliyun-v2-typescript-sdk-0.1.1.tgz#1bbee6ecfb9224436ac29d0c7685895c3b6560e9"
+  integrity sha512-z/nqg4CIoiWVqBkVrdX9HfWYa+Zaq26ZY8R/4EdbWh5M0oSdLtUQv6w0vhTH5WANbJC1kT8eXkMlbPcoTX2eTg==
+  dependencies:
+    "@alicloud/dds20151201" "1.0.3"
+    "@alicloud/rds20140815" "2.0.7"
+    "@alicloud/slb20140515" "2.0.2"
+    ali-oss "^6.17.1"
+    source-map-support "^0.5.21"
 
 ansi-colors@4.1.1:
   version "4.1.1"
@@ -2132,7 +2313,7 @@ ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-any-promise@^1.0.0:
+any-promise@^1.0.0, any-promise@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
   integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
@@ -2428,6 +2609,11 @@ bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5, bluebird@^3.7.2:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
+bowser@^1.6.0:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.4.tgz#890c58a2813a9d3243704334fa81b96a5c150c9a"
+  integrity sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -2491,6 +2677,11 @@ buffer@4.9.2:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+builtin-status-codes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
+  integrity sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==
+
 builtins@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
@@ -2505,6 +2696,11 @@ byte-size@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/byte-size/-/byte-size-5.0.1.tgz#4b651039a5ecd96767e71a3d7ed380e48bed4191"
   integrity sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==
+
+bytes@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
+  integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
 cacache@^12.0.0, cacache@^12.0.3:
   version "12.0.4"
@@ -2559,6 +2755,14 @@ cacheable-request@^7.0.1:
     lowercase-keys "^2.0.0"
     normalize-url "^4.1.0"
     responselike "^2.0.0"
+
+call-bind@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
 
 call-me-maybe@^1.0.1:
   version "1.0.1"
@@ -2958,6 +3162,11 @@ constantinople@^3.0.1, constantinople@^3.1.2:
     babel-types "^6.26.0"
     babylon "^6.18.0"
 
+content-type@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
+
 conventional-changelog-angular@^5.0.3:
   version "5.0.10"
   resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.10.tgz#5cf7b00dd315b6a6a558223c80d5ef24ddb34205"
@@ -3065,6 +3274,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-to@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/copy-to/-/copy-to-2.0.1.tgz#2680fbb8068a48d08656b6098092bdafc906f4a5"
+  integrity sha512-3DdaFaU/Zf1AnpLiFDeNCD4TOWe3Zl2RZaTzUvWiIk5ERzcCodOE20Vqq4fzCbNoHURFHT4/us/Lfq+S2zyY4w==
+
 core-js@^2.4.0, core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
@@ -3074,6 +3288,11 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+core-util-is@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cosmiconfig@^5.1.0:
   version "5.2.1"
@@ -3160,6 +3379,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
+  integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
+
 date-and-time@^0.13.0:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.13.1.tgz#d12ba07ac840d5b112dc4c83f8a03e8a51f78dd6"
@@ -3169,6 +3393,11 @@ date-utils@*:
   version "1.2.21"
   resolved "https://registry.yarnpkg.com/date-utils/-/date-utils-1.2.21.tgz#61fb16cdc1274b3c9acaaffe9fc69df8720a2b64"
   integrity sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q=
+
+dateformat@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.2.0.tgz#4065e2013cf9fb916ddfd82efb506ad4c6769062"
+  integrity sha512-GODcnWq3YGoTnygPfi02ygEiRxqUxpJwuRHjdhJYuxpcZmDq4rjBiXYmbCCzStxo176ixfLT6i4NPwQooRySnw==
 
 dateformat@^3.0.0:
   version "3.0.3"
@@ -3200,7 +3429,7 @@ debug@4, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@^2.2.0, debug@^2.3.3:
+debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -3259,10 +3488,17 @@ deep-equal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
-deep-is@^0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
+default-user-agent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/default-user-agent/-/default-user-agent-1.0.0.tgz#16c46efdcaba3edc45f24f2bd4868b01b7c2adc6"
+  integrity sha512-bDF7bg6OSNcSwFWPu4zYKpVkJZQYVrAANMYB8bc9Szem1D0yKdm4sa/rOCs2aC9+2GMqQ7KnwtZRvDhmLF0dXw==
+  dependencies:
+    os-name "~1.0.3"
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -3305,6 +3541,16 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+degenerator@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-3.0.2.tgz#6a61fcc42a702d6e50ff6023fe17bff435f68235"
+  integrity sha512-c0mef3SNQo56t6urUU6tdQAs+ThoD0o9B9MJ8HEt7NQcGEILCRFqQb7ZbP9JAv+QF1Ky5plydhMR/IrqWDm+TQ==
+  dependencies:
+    ast-types "^0.13.2"
+    escodegen "^1.8.1"
+    esprima "^4.0.0"
+    vm2 "^3.9.8"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -3315,10 +3561,20 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+depd@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
 deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
+
+destroy@^1.0.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
+  integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
 detect-indent@^5.0.0:
   version "5.0.0"
@@ -3342,6 +3598,13 @@ diff@4.0.2, diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
+digest-header@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/digest-header/-/digest-header-0.0.1.tgz#11ccf6deec5766ac379744d901c12cba49514be6"
+  integrity sha512-Qi0KOZgRnkQJuvMWbs1ZRRajEnbsMU8xlJI4rHIbPC+skHQ30heO5cIHpUFT4jAvAe+zPtdavLSAxASqoyZ3cg==
+  dependencies:
+    utility "0.1.11"
 
 dir-glob@^2.2.2:
   version "2.2.2"
@@ -3442,6 +3705,11 @@ ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
   dependencies:
     safe-buffer "^5.0.1"
 
+ee-first@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+  integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -3464,6 +3732,11 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   dependencies:
     once "^1.4.0"
+
+end-or-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/end-or-error/-/end-or-error-1.0.1.tgz#dc7a6210fe78d372fee24a8b4899dbd155414dcb"
+  integrity sha512-OclLMSug+k2A0JKuf494im25ANRBVW8qsjmwbgX7lQ8P82H21PQ1PWkoYwb9y5yMBS69BPlwtzdIFClo3+7kOQ==
 
 ent@^2.2.0:
   version "2.2.0"
@@ -3552,6 +3825,11 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
+escape-html@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -3565,6 +3843,18 @@ escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+escodegen@^1.8.1:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
+  integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
 
 eslint-plugin-simple-import-sort@^7.0.0:
   version "7.0.0"
@@ -3654,7 +3944,7 @@ espree@^9.3.1:
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^3.3.0"
 
-esprima@^4.0.0, esprima@~4.0.0:
+esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
 
@@ -3672,7 +3962,7 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^4.1.1:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -3835,7 +4125,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@^2.0.6:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -3870,6 +4160,11 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-uri-to-path@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz#7b415aeba227d575851e0a5b0c640d7656403fba"
+  integrity sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -3996,6 +4291,15 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+formstream@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formstream/-/formstream-1.1.1.tgz#17259d2440c35ca9736db9f45fb3ba3f8669c750"
+  integrity sha512-yHRxt3qLFnhsKAfhReM4w17jP+U1OlhUjnKPPtonwKbIJO7oBP0MvoxkRUwb8AU9n0MIkYy5X5dK6pQnbj+R2Q==
+  dependencies:
+    destroy "^1.0.4"
+    mime "^2.5.2"
+    pause-stream "~0.0.11"
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -4045,6 +4349,14 @@ fsevents@~2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+
+ftp@^0.3.10:
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/ftp/-/ftp-0.3.10.tgz#9197d861ad8142f3e63d5a83bfe4c59f7330885d"
+  integrity sha512-faFVML1aBx2UoDStmLwv2Wptt4vw5x03xxX172nhA5Y5HBshW5JweqQ2W4xL4dezQTG8inJsuYcpPHHU3X5OTQ==
+  dependencies:
+    readable-stream "1.1.x"
+    xregexp "2.0.0"
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -4148,6 +4460,15 @@ get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
+get-intrinsic@^1.0.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.2.tgz#336975123e05ad0b7ba41f152ee4aadbea6cf598"
+  integrity sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.3"
+
 get-pkg-repo@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz#c73b489c06d80cc5536c2c853f9e05232056972d"
@@ -4163,6 +4484,11 @@ get-port@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-4.2.0.tgz#e37368b1e863b7629c43c5a323625f95cf24b119"
   integrity sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==
+
+get-ready@^1.0.0, get-ready@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-ready/-/get-ready-1.0.0.tgz#f91817f1e9adecfea13a562adfc8de883ab34782"
+  integrity sha512-mFXCZPJIlcYcth+N8267+mghfYN9h3EhsDa6JSnbA3Wrhh/XFpuowviFcsDeYZtKspQyWyJqfs4O6P8CHeTwzw==
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -4185,6 +4511,18 @@ get-stream@^5.1.0:
   integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
+
+get-uri@3:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-3.0.2.tgz#f0ef1356faabc70e1f9404fa3b66b2ba9bfc725c"
+  integrity sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==
+  dependencies:
+    "@tootallnate/once" "1"
+    data-uri-to-buffer "3"
+    debug "4"
+    file-uri-to-path "2"
+    fs-extra "^8.1.0"
+    ftp "^0.3.10"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -4290,6 +4628,18 @@ glob@7.1.6, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.2:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -4480,6 +4830,11 @@ has-symbols@^1.0.0, has-symbols@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
+has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
+
 has-unicode@^2.0.0, has-unicode@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -4564,6 +4919,17 @@ http-cache-semantics@^4.0.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
+http-errors@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
+  integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
+  dependencies:
+    depd "2.0.0"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses "2.0.1"
+    toidentifier "1.0.1"
+
 http-proxy-agent@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
@@ -4572,7 +4938,7 @@ http-proxy-agent@^2.1.0:
     agent-base "4"
     debug "3.1.0"
 
-http-proxy-agent@^4.0.0:
+http-proxy-agent@^4.0.0, http-proxy-agent@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
   integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
@@ -4598,6 +4964,14 @@ http2-wrapper@^1.0.0-beta.5.2:
     quick-lru "^5.1.1"
     resolve-alpn "^1.0.0"
 
+https-proxy-agent@5:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 https-proxy-agent@^2.2.3:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
@@ -4614,7 +4988,15 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-humanize-ms@^1.2.1:
+httpx@^2.2.0, httpx@^2.2.6:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/httpx/-/httpx-2.2.7.tgz#1e34198146e32ca3305a66c11209559e1cbeba09"
+  integrity sha512-Wjh2JOAah0pdczfqL8NC5378G7jMt0Zcpn8U+yyxAiejjlagzSTQgJHuVvka2VNPQlKfoGehYRc79WKq9E4gDw==
+  dependencies:
+    "@types/node" "^14"
+    debug "^4.1.1"
+
+humanize-ms@^1.2.0, humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
   integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
@@ -4637,7 +5019,7 @@ husky@^4.3.0:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
-iconv-lite@^0.4.24, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.15, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4744,7 +5126,7 @@ inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4753,6 +5135,11 @@ ini@^1.3.2, ini@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+ini@^1.3.5:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 init-package-json@^1.10.3:
   version "1.10.3"
@@ -4796,6 +5183,11 @@ ip@1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
+
+ip@^1.1.5:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.8.tgz#ae05948f6b075435ed3307acce04629da8cdbf48"
+  integrity sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -4847,6 +5239,11 @@ is-ci@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
   dependencies:
     ci-info "^2.0.0"
+
+is-class-hotfix@~0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/is-class-hotfix/-/is-class-hotfix-0.0.6.tgz#a527d31fb23279281dde5f385c77b5de70a72435"
+  integrity sha512-0n+pzCC6ICtVr/WXnN2f03TK/3BfXY7me4cjCAqT8TYXEl0+JBRoqBo94JJHXcyDSLUeWbNX8Fvy5g5RJdAstQ==
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -5074,6 +5471,15 @@ is-text-path@^1.0.1:
   dependencies:
     text-extensions "^1.0.0"
 
+is-type-of@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-type-of/-/is-type-of-1.2.1.tgz#e263ec3857aceb4f28c47130ec78db09a920f8c5"
+  integrity sha512-uK0kyX9LZYhSDS7H2sVJQJop1UnWPWmo5RvR3q2kFH6AUHYs7sOrVg0b4nyBHw29kRRNFofYN/JbHZDlHiItTA==
+  dependencies:
+    core-util-is "^1.0.2"
+    is-class-hotfix "~0.0.6"
+    isstream "~0.1.2"
+
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -5093,6 +5499,11 @@ is@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/is/-/is-3.3.0.tgz#61cff6dd3c4193db94a3d62582072b44e5645d79"
   integrity sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -5147,6 +5558,11 @@ jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
+
+js-base64@^2.5.2:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
+  integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
 
 js-stringify@^1.0.1:
   version "1.0.2"
@@ -5287,6 +5703,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jstoxml@^2.0.0:
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/jstoxml/-/jstoxml-2.2.9.tgz#2eebd5e55383fe66a375022ca0aa88f77bc4fb84"
+  integrity sha512-OYWlK0j+roh+eyaMROlNbS5cd5R25Y+IUpdl7cNdB8HNrkgwQzIS7L9MegxOiWNBj9dQhA/yAxiMwCC5mwNoBw==
+
 jstransformer@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/jstransformer/-/jstransformer-1.0.0.tgz#ed8bf0921e2f3f1ed4d5c1a44f68709ed24722c3"
@@ -5364,12 +5785,26 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+kitx@^2.0.0, kitx@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/kitx/-/kitx-2.1.0.tgz#fc7fbf78eb6ed7a5a3fd2d7afb3011e29d0e44c8"
+  integrity sha512-C/5v9MtIX7aHGOjwn5BmrrbNkJSf7i0R5mRzmh13GSAdRqQ7bYQo/Su2pTYNylFicqKNTVX3HML9k1u8k51+pQ==
+  dependencies:
+    "@types/node" "^12.0.2"
+
 klaw@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-3.0.0.tgz#b11bec9cf2492f06756d6e809ab73a2910259146"
   integrity sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==
   dependencies:
     graceful-fs "^4.1.9"
+
+ko-sleep@^1.0.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/ko-sleep/-/ko-sleep-1.1.4.tgz#56462fba835e07bb8c26cfa083f9893a3fde5469"
+  integrity sha512-s05WGpvvzyTuRlRE8fM7ru2Z3O+InbJuBcckTWKg2W+2c1k6SnFa3IfiSSt0/peFrlYAXgNoxuJWWVNmWh+K/A==
+  dependencies:
+    ms "*"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -5407,6 +5842,14 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
+
+levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
@@ -5783,6 +6226,11 @@ meow@^7.0.0:
     type-fest "^0.13.1"
     yargs-parser "^18.1.3"
 
+merge-descriptors@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+  integrity sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -5837,6 +6285,11 @@ mime@^2.2.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
   integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
 
+mime@^2.4.5, mime@^2.5.2:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
+
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
@@ -5868,6 +6321,13 @@ minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist-options@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-3.0.2.tgz#fba4c8191339e13ecf4d61beb03f070103f3d954"
@@ -5888,6 +6348,11 @@ minimist-options@^4.0.2:
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+minimist@^1.1.0:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minimist@^1.1.3, minimist@^1.2.5:
   version "1.2.5"
@@ -6014,6 +6479,11 @@ mri@^1.1.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.4.tgz#7cb1dd1b9b40905f1fac053abe25b6720f44744a"
 
+ms@*:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -6046,7 +6516,18 @@ mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-mz@^2.5.0:
+mz-modules@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mz-modules/-/mz-modules-2.1.0.tgz#7f529877afd0d42f409a7463b96986d61cfbcf96"
+  integrity sha512-sjk8lcRW3vrVYnZ+W+67L/2rL+jbO5K/N6PFGIcLWTiYytNr22Ah9FDXFs+AQntTM1boZcoHi5qS+CV1seuPog==
+  dependencies:
+    glob "^7.1.2"
+    ko-sleep "^1.0.3"
+    mkdirp "^0.5.1"
+    pump "^3.0.0"
+    rimraf "^2.6.1"
+
+mz@^2.5.0, mz@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
   integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
@@ -6086,6 +6567,11 @@ neo-async@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+netmask@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
+  integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -6279,6 +6765,11 @@ object-inspect@^1.7.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
 
+object-inspect@^1.9.0:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
+  integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
+
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -6346,6 +6837,18 @@ opencollective-postinstall@^2.0.2:
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
+optionator@^0.8.1:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
+  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.6"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    word-wrap "~1.2.3"
+
 optionator@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
@@ -6371,6 +6874,14 @@ os-name@^3.1.0:
     macos-release "^2.2.0"
     windows-release "^3.1.0"
 
+os-name@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/os-name/-/os-name-1.0.3.tgz#1b379f64835af7c5a7f498b357cb95215c159edf"
+  integrity sha512-f5estLO2KN8vgtTRaILIgEGBoBrMnZ3JQ7W9TMZCnOIGwHe8TRGSpcagnWDo+Dfhd/z08k9Xe75hvciJJ8Qaew==
+  dependencies:
+    osx-release "^1.0.0"
+    win-release "^1.0.0"
+
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -6383,6 +6894,13 @@ osenv@^0.1.4, osenv@^0.1.5:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+osx-release@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/osx-release/-/osx-release-1.1.0.tgz#f217911a28136949af1bf9308b241e2737d3cd6c"
+  integrity sha512-ixCMMwnVxyHFQLQnINhmIpWqXIfS2YOXchwQrk+OFzmo6nDjQ0E4KXAyyUh0T0MZgV4bUhkRrAbVqlE4yLVq4A==
+  dependencies:
+    minimist "^1.1.0"
 
 p-cancelable@^2.0.0:
   version "2.1.1"
@@ -6501,6 +7019,30 @@ p-waterfall@^1.0.0:
   integrity sha1-ftlLPOszMngjU69qrhGqn8I1uwA=
   dependencies:
     p-reduce "^1.0.0"
+
+pac-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-5.0.0.tgz#b718f76475a6a5415c2efbe256c1c971c84f635e"
+  integrity sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ==
+  dependencies:
+    "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
+    get-uri "3"
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "5"
+    pac-resolver "^5.0.0"
+    raw-body "^2.2.0"
+    socks-proxy-agent "5"
+
+pac-resolver@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-5.0.1.tgz#c91efa3a9af9f669104fa2f51102839d01cde8e7"
+  integrity sha512-cy7u00ko2KVgBAjuhevqpPeHIkCIqPe1v24cydhWjmeuzaBfmUWFCZJ1iAh5TuVzVZoUzXIW7K8sMYOZ84uZ9Q==
+  dependencies:
+    degenerator "^3.0.2"
+    ip "^1.1.5"
+    netmask "^2.0.2"
 
 parallel-transform@^1.1.0:
   version "1.2.0"
@@ -6633,6 +7175,13 @@ pathval@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
 
+pause-stream@~0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  integrity sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==
+  dependencies:
+    through "~2.3"
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -6687,6 +7236,11 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+platform@^1.3.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
+  integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -6703,6 +7257,11 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+  integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
 prettier@^1.15.3:
   version "1.18.2"
@@ -6834,6 +7393,25 @@ protoduck@^5.0.1:
   integrity sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==
   dependencies:
     genfun "^5.0.0"
+
+proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-5.0.0.tgz#d31405c10d6e8431fde96cba7a0c027ce01d633b"
+  integrity sha512-gkH7BkvLVkSfX9Dk27W6TyNOWWZWRilRfk1XxGNWOYJ2TuedAv1yFpCaU9QSBmBe716XOTNpYNOzhysyw8xn7g==
+  dependencies:
+    agent-base "^6.0.0"
+    debug "4"
+    http-proxy-agent "^4.0.0"
+    https-proxy-agent "^5.0.0"
+    lru-cache "^5.1.1"
+    pac-proxy-agent "^5.0.0"
+    proxy-from-env "^1.0.0"
+    socks-proxy-agent "^5.0.0"
+
+proxy-from-env@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -6997,6 +7575,13 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
+qs@^6.4.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@^6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -7026,6 +7611,16 @@ quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
+raw-body@^2.2.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
+  integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
+  dependencies:
+    bytes "3.1.2"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
 
 react-ace@^6.5.0:
   version "6.6.0"
@@ -7163,6 +7758,16 @@ read@1, read@~1.0.1:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readable-stream@1.1.x:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  integrity sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 "readable-stream@2 || 3", readable-stream@3, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.0"
@@ -7391,7 +7996,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -7463,6 +8068,13 @@ sax@>=0.6.0:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
+sdk-base@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/sdk-base/-/sdk-base-2.0.1.tgz#ba40289e8bdf272ed11dd9ea97eaf98e036d24c6"
+  integrity sha512-eeG26wRwhtwYuKGCDM3LixCaxY27Pa/5lK4rLKhQa7HBjJ3U3Y+f81MMZQRsDw/8SC2Dao/83yJTXJ8aULuN8Q==
+  dependencies:
+    get-ready "~1.0.0"
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
@@ -7472,7 +8084,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.4.1, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.0.1, semver@^5.4.1, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
 
@@ -7517,6 +8129,11 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
+setprototypeof@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
+
 shallow-clone@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
@@ -7546,6 +8163,15 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
+
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -7569,10 +8195,20 @@ slide@^1.1.6:
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
   integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
 
+sm3@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sm3/-/sm3-1.0.3.tgz#0051f0cc948c983944843136e7baa244eec5cd49"
+  integrity sha512-KyFkIfr8QBlFG3uc3NaljaXdYcsbRy1KrSfc4tsQV8jW68jAktGeOcifu530Vx/5LC+PULHT0Rv8LiI8Gw+c1g==
+
 smart-buffer@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
   integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
+
+smart-buffer@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
+  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
 snakeize@^0.1.0:
   version "0.1.0"
@@ -7609,6 +8245,15 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+socks-proxy-agent@5, socks-proxy-agent@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz#032fb583048a29ebffec2e6a73fca0761f48177e"
+  integrity sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==
+  dependencies:
+    agent-base "^6.0.2"
+    debug "4"
+    socks "^2.3.3"
+
 socks-proxy-agent@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz#3c8991f3145b2799e70e11bd5fbc8b1963116386"
@@ -7616,6 +8261,14 @@ socks-proxy-agent@^4.0.0:
   dependencies:
     agent-base "~4.2.1"
     socks "~2.3.2"
+
+socks@^2.3.3:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.2.tgz#ec042d7960073d40d94268ff3bb727dc685f111a"
+  integrity sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "^4.2.0"
 
 socks@~2.3.2:
   version "2.3.3"
@@ -7647,6 +8300,14 @@ source-map-support@^0.5.17:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@^0.5.21:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -7763,6 +8424,16 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
+statuses@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
+  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+statuses@^1.3.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
 stream-each@^1.1.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz#ebe27a0c389b04fbcc233642952e10731afa9bae"
@@ -7778,10 +8449,26 @@ stream-events@^1.0.1, stream-events@^1.0.4, stream-events@^1.0.5:
   dependencies:
     stubs "^3.0.0"
 
+stream-http@2.8.2:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.2.tgz#4126e8c6b107004465918aa2fc35549e77402c87"
+  integrity sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==
+  dependencies:
+    builtin-status-codes "^3.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.3.6"
+    to-arraybuffer "^1.0.0"
+    xtend "^4.0.0"
+
 stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+stream-wormhole@^1.0.4:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stream-wormhole/-/stream-wormhole-1.1.0.tgz#300aff46ced553cfec642a05251885417693c33d"
+  integrity sha512-gHFfL3px0Kctd6Po0M8TzEvt3De/xu6cnRrjlfYNhwbhLPLwigI2t1nc6jrzNuaYg5C4YF78PPFuQPzRiqn9ew==
 
 string-format-obj@^1.1.1:
   version "1.1.1"
@@ -7845,6 +8532,11 @@ string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -8060,7 +8752,7 @@ through2@^4.0.0:
   dependencies:
     readable-stream "3"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6:
+through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@~2.3:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -8071,6 +8763,11 @@ tmp@^0.0.33:
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+to-arraybuffer@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
+  integrity sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==
 
 to-fast-properties@^1.0.3:
   version "1.0.3"
@@ -8113,6 +8810,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toidentifier@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
 token-stream@0.0.1:
   version "0.0.1"
@@ -8220,6 +8922,13 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  integrity sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==
+  dependencies:
+    prelude-ls "~1.1.2"
+
 type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
@@ -8311,6 +9020,13 @@ umask@^1.1.0:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.10.2.tgz#73d6aa3668f3188e4adb0f1943bd12cfd7efaaaf"
   integrity sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==
 
+unescape@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unescape/-/unescape-1.0.1.tgz#956e430f61cad8a4d57d82c518f5e6cc5d0dda96"
+  integrity sha512-O0+af1Gs50lyH1nUu3ZyYS1cRh01Q/kUKatTOkSs7jukXE6/NebucDVxyiDsA9AQ4JC1V1jUH9EO8JX2nMDgGQ==
+  dependencies:
+    extend-shallow "^2.0.1"
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -8361,6 +9077,11 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+unpipe@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+  integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
+
 unset-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
@@ -8394,6 +9115,27 @@ url@0.10.3:
     punycode "1.3.2"
     querystring "0.2.0"
 
+urllib@^2.33.1:
+  version "2.38.0"
+  resolved "https://registry.yarnpkg.com/urllib/-/urllib-2.38.0.tgz#5c0088f42091ef1cef07bb2547677487170414f5"
+  integrity sha512-8nim/hlS5GXtWe2BJ6usPimKx5VE3nenXgcG26ip5Ru+MKPddINH8uLpZ948n6ADhlus6A0AYj8xTYNmGQi8yA==
+  dependencies:
+    any-promise "^1.3.0"
+    content-type "^1.0.2"
+    debug "^2.6.9"
+    default-user-agent "^1.0.0"
+    digest-header "^0.0.1"
+    ee-first "~1.1.1"
+    formstream "^1.1.0"
+    humanize-ms "^1.2.0"
+    iconv-lite "^0.4.15"
+    ip "^1.1.5"
+    proxy-agent "^5.0.0"
+    pump "^3.0.0"
+    qs "^6.4.0"
+    statuses "^1.3.1"
+    utility "^1.16.1"
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -8410,6 +9152,24 @@ util-promisify@^2.1.0:
   integrity sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
+
+utility@0.1.11:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/utility/-/utility-0.1.11.tgz#fde60cf9b4e4751947a0cf5d104ce29367226715"
+  integrity sha512-epFsJ71+/yC7MKMX7CM9azP31QBIQhywkiBUj74i/T3Y2TXtEor26QBkat7lGamrrNTr5CBI1imd/8F0Bmqw4g==
+  dependencies:
+    address ">=0.0.1"
+
+utility@^1.16.1, utility@^1.8.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/utility/-/utility-1.17.0.tgz#60819f712a6e0ce774f52fb1d691992a5f59d362"
+  integrity sha512-KdVkF9An/0239BJ4+dqOa7NPrPIOeQE9AGfx0XS16O9DBiHNHRJMoeU5nL6pRGAkgJOqdOu8R4gBRcXnAocJKw==
+  dependencies:
+    copy-to "^2.0.1"
+    escape-html "^1.0.3"
+    mkdirp "^0.5.1"
+    mz "^2.7.0"
+    unescape "^1.0.1"
 
 uuid@3.3.2:
   version "3.3.2"
@@ -8453,6 +9213,14 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vm2@^3.9.8:
+  version "3.9.9"
+  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.9.tgz#c0507bc5fbb99388fad837d228badaaeb499ddc5"
+  integrity sha512-xwTm7NLh/uOjARRBs8/95H0e8fT3Ukw5D/JJWhxMbhKzNh1Nu981jQKvkep9iKYNxzlVrdzD0mlBGkDKZWprlw==
+  dependencies:
+    acorn "^8.7.0"
+    acorn-walk "^8.2.0"
 
 void-elements@^2.0.1:
   version "2.0.1"
@@ -8546,6 +9314,13 @@ wide-align@1.1.3, wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
+win-release@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/win-release/-/win-release-1.1.1.tgz#5fa55e02be7ca934edfc12665632e849b72e5209"
+  integrity sha512-iCRnKVvGxOQdsKhcQId2PXV1vV3J/sDPXKA4Oe9+Eti2nb2ESEsYHRYls/UjoUW3bIc5ZDO8dTH50A/5iVN+bw==
+  dependencies:
+    semver "^5.0.1"
+
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
@@ -8566,7 +9341,7 @@ with@^5.0.0:
     acorn "^3.1.0"
     acorn-globals "^3.0.0"
 
-word-wrap@^1.2.3:
+word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
@@ -8672,7 +9447,7 @@ xml2js@0.4.19:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
 
-xml2js@^0.4.19:
+xml2js@^0.4.16, xml2js@^0.4.19, xml2js@^0.4.22:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
   integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
@@ -8705,7 +9480,12 @@ xpath.js@~1.1.0:
   resolved "https://registry.yarnpkg.com/xpath.js/-/xpath.js-1.1.0.tgz#3816a44ed4bb352091083d002a383dd5104a5ff1"
   integrity sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ==
 
-xtend@~4.0.1:
+xregexp@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-2.0.0.tgz#52a63e56ca0b84a7f3a5f3d61872f126ad7a5943"
+  integrity sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA==
+
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
Fixes #121 and #124 

## Proposed Changes

  - add the Aliyun SDK as part of workspace `class-generator`
  - added parser for Aliyun code generator
  - added tests for aliyun code generator

### Side Note

There was a run of the global formatter, this is a one time operation and due to this all files have undergone formatting changes due to which they show up in the changelog. To ease the review, attaching the files undergone code changes as part of the PR:

- `generator/node-cloud.yml`
- `.prettierignore`
- `generator/parsers/aliyun/parser.ts`
- `generator/generators/aliyun/generator.ts`
- `generator/test/parsers/aliyun/parser.test.ts`